### PR TITLE
Fix ciphertool to be able to run it with a custom keystore with WSO2 EI conf dir path

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
@@ -82,7 +82,7 @@ public class CipherTool {
                     System.setProperty(property, Constants.TRUE);
                 } else if (property.equals(Constants.CHANGE)) {
                     System.setProperty(property, Constants.TRUE);
-                } else if (property.substring(0, 8).equals(Constants.CONSOLE_PASSWORD_PARAM)) {
+                } else if (property.length() >= 8 && property.substring(0, 8).equals(Constants.CONSOLE_PASSWORD_PARAM)) {
                     System.setProperty(Constants.KEYSTORE_PASSWORD, property.substring(9));
                 } else {
                     System.out.println("This option is not define!");

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -29,8 +29,6 @@ import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Properties;
 
 public class Utils {
@@ -203,6 +201,12 @@ public class Utils {
 
         //Verify if this is WSO2 environment
         Path path = Paths.get(homeFolder, Constants.REPOSITORY_DIR, Constants.CONF_DIR, Constants.CARBON_CONFIG_FILE);
+        boolean hasConfigInRepository = true;
+        if (!Files.exists(path)) {
+        	//Try WSO2 EI alternate path
+        	path = Paths.get(homeFolder, Constants.CONF_DIR, Constants.CARBON_CONFIG_FILE);
+        	hasConfigInRepository = false;
+        }
 
         if (Files.exists(path)) {
             //WSO2 Environment
@@ -213,22 +217,27 @@ public class Utils {
 
                 keyStoreFile = Utils.getValueFromXPath(document.getDocumentElement(),
                                                        Constants.PrimaryKeyStore.PRIMARY_KEY_LOCATION_XPATH);
-                keyStoreFile = homeFolder + keyStoreFile.substring((keyStoreFile.indexOf('}')) + 1);
-                System.setProperty(Constants.PrimaryKeyStore.PRIMARY_KEY_LOCATION_PROPERTY, keyStoreFile);
+                keyStoreFile = homeFolder + File.separator + keyStoreFile.substring((keyStoreFile.indexOf('}')) + 1);
                 keyType = Utils.getValueFromXPath(document.getDocumentElement(),
                                                   Constants.PrimaryKeyStore.PRIMARY_KEY_TYPE_XPATH);
                 keyAlias = Utils.getValueFromXPath(document.getDocumentElement(),
                                                    Constants.PrimaryKeyStore.PRIMARY_KEY_ALIAS_XPATH);
 
-                secretConfFile = homeFolder + File.separator + Constants.REPOSITORY_DIR +
-                                 File.separator + Constants.CONF_DIR + File.separator + Constants.SECURITY_DIR +
-                                 File.separator + Constants.SECRET_PROPERTY_FILE;
-                cipherTextPropFile = Constants.REPOSITORY_DIR + File.separator + Constants.CONF_DIR + File.separator +
-                                     Constants.SECURITY_DIR + File.separator + Constants.CIPHER_TEXT_PROPERTY_FILE;
-                cipherToolPropFile =
-                        homeFolder + File.separator + Constants.REPOSITORY_DIR + File.separator + Constants.CONF_DIR +
-                        File.separator + Constants.SECURITY_DIR + File.separator + Constants.CIPHER_TOOL_PROPERTY_FILE;
-
+                if (hasConfigInRepository) {
+	                secretConfFile = Constants.REPOSITORY_DIR + File.separator + Constants.CONF_DIR + File.separator +
+	                                 Constants.SECURITY_DIR + File.separator + Constants.SECRET_PROPERTY_FILE;
+	                cipherTextPropFile = Constants.REPOSITORY_DIR + File.separator + Constants.CONF_DIR + File.separator +
+	                                     Constants.SECURITY_DIR + File.separator + Constants.CIPHER_TEXT_PROPERTY_FILE;
+	                cipherToolPropFile = Constants.REPOSITORY_DIR + File.separator + Constants.CONF_DIR + File.separator +
+	                                     Constants.SECURITY_DIR + File.separator + Constants.CIPHER_TOOL_PROPERTY_FILE;
+                } else {
+	                secretConfFile = Constants.CONF_DIR + File.separator + Constants.SECURITY_DIR + File.separator +
+	                                 Constants.SECRET_PROPERTY_FILE;
+		            cipherTextPropFile = Constants.CONF_DIR + File.separator + Constants.SECURITY_DIR + File.separator +
+		                                 Constants.CIPHER_TEXT_PROPERTY_FILE;
+		            cipherToolPropFile = Constants.CONF_DIR + File.separator + Constants.SECURITY_DIR + File.separator +
+		                                 Constants.CIPHER_TOOL_PROPERTY_FILE;
+                }
             } catch (ParserConfigurationException e) {
                 throw new CipherToolException(
                         "Error reading primary key Store details from " + Constants.CARBON_CONFIG_FILE + " file ", e);
@@ -240,7 +249,6 @@ public class Utils {
                         "Error reading primary key Store details from " + Constants.CARBON_CONFIG_FILE + " file ", e);
             }
         } else {
-
             Path standaloneConfigPath =
                     Paths.get(homeFolder, Constants.CONF_DIR, Constants.CIPHER_STANDALONE_CONFIG_PROPERTY_FILE);
             if (!Files.exists(standaloneConfigPath)) {
@@ -256,8 +264,7 @@ public class Utils {
             keyStoreFile = standaloneConfigProp.getProperty(Constants.PrimaryKeyStore.PRIMARY_KEY_LOCATION_PROPERTY);
             keyType = standaloneConfigProp.getProperty(Constants.PrimaryKeyStore.PRIMARY_KEY_TYPE_PROPERTY);
             keyAlias = standaloneConfigProp.getProperty(Constants.PrimaryKeyStore.PRIMARY_KEY_ALIAS_PROPERTY);
-            secretConfPropFile = standaloneConfigProp.getProperty(Constants.SECRET_PROPERTY_FILE_PROPERTY);
-            secretConfFile = homeFolder + File.separator + secretConfPropFile;
+            secretConfFile = standaloneConfigProp.getProperty(Constants.SECRET_PROPERTY_FILE_PROPERTY);
             cipherTextPropFile = standaloneConfigProp.getProperty(Constants.CIPHER_TEXT_PROPERTY_FILE_PROPERTY);
             cipherToolPropFile = standaloneConfigProp.getProperty(Constants.CIPHER_TOOL_PROPERTY_FILE_PROPERTY);
         }


### PR DESCRIPTION
## Purpose
WSO2 Enterprise Integrator has configuration files in the <WSO2_EI_HOME>/conf/ directory instead of <WSO2_EI_HOME>/repository/conf/.

The Cipher Tool tries to load the <WSO2_EI_HOME>/repository/conf/carbon.xml to read the keystore location and other configuration values and fall back to default configuration values if the file doesn't exist.

Since WSO2 EI has it's configuration files in <WSO2_EI_HOME>/conf/, the configured values are never read, so it is impossible to configure a custom keystore file.

## Goals
This patch add some conditions to read the keystore location from the WSO2 EI configuration file. It also set the correct paths for the secret conf, cipher text and cipher tool properties files.

## Release note
> Fix ciphertool to be able to run it with a custom keystore with WSO2 EI conf dir path

## Test environment
> Windows / JDK8 / Google Chrome
> RHEL6 / JDK8 / Mozilla Firefox
