### PR TITLE
Fix the java.nio.file.InvalidPathException occurred in Windows Environments

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -217,7 +217,7 @@ public class Utils {
 
                 keyStoreFile = Utils.getValueFromXPath(document.getDocumentElement(),
                                                        Constants.PrimaryKeyStore.PRIMARY_KEY_LOCATION_XPATH);
-                keyStoreFile = homeFolder + File.separator + keyStoreFile.substring((keyStoreFile.indexOf('}')) + 1);
+                keyStoreFile = keyStoreFile.substring((keyStoreFile.indexOf('}')) + 1);
                 keyType = Utils.getValueFromXPath(document.getDocumentElement(),
                                                   Constants.PrimaryKeyStore.PRIMARY_KEY_TYPE_XPATH);
                 keyAlias = Utils.getValueFromXPath(document.getDocumentElement(),


### PR DESCRIPTION
## Purpose
> Fix the java.nio.file.InvalidPathException occurred in Windows Environments by resolving the issue https://github.com/wso2/cipher-tool/issues/36

## Goals
> Removed the additional CARBON_HOME path added to the keystore file path

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
> N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Tested on Linux based OS and Windows based OS with JDK 1.8

## Learning
> N/A
