### PR TITLE
Use InternalKeystore for encryption if configured

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
@@ -42,14 +42,20 @@ public class Constants {
     public static final String SECRET_PROPERTY_FILE_PROPERTY = "secret.conf.properties.file";
     public static final String CIPHER_TRANSFORMATION_SYSTEM_PROPERTY = "org.wso2.CipherTransformation";
 
-    public static final class PrimaryKeyStore {
-        public static final String PRIMARY_KEY_LOCATION_XPATH = "//Server/Security/KeyStore/Location";
-        public static final String PRIMARY_KEY_TYPE_XPATH = "//Server/Security/KeyStore/Type";
-        public static final String PRIMARY_KEY_ALIAS_XPATH = "//Server/Security/KeyStore/KeyAlias";
+    public static final String KEY_LOCATION_PROPERTY = "primary.key.location";
+    public static final String KEY_TYPE_PROPERTY = "primary.key.type";
+    public static final String KEY_ALIAS_PROPERTY = "primary.key.alias";
 
-        public static final String PRIMARY_KEY_LOCATION_PROPERTY = "primary.key.location";
-        public static final String PRIMARY_KEY_TYPE_PROPERTY = "primary.key.type";
-        public static final String PRIMARY_KEY_ALIAS_PROPERTY = "primary.key.alias";
+    public static final class PrimaryKeyStore {
+        public static final String KEY_LOCATION_XPATH = "//Server/Security/KeyStore/Location";
+        public static final String KEY_TYPE_XPATH = "//Server/Security/KeyStore/Type";
+        public static final String KEY_ALIAS_XPATH = "//Server/Security/KeyStore/KeyAlias";
+    }
+
+    public static final class InternalKeyStore {
+        public static final String KEY_LOCATION_XPATH = "//Server/Security/InternalKeyStore/Location";
+        public static final String KEY_TYPE_XPATH = "//Server/Security/InternalKeyStore/Type";
+        public static final String KEY_ALIAS_XPATH = "//Server/Security/InternalKeyStore/KeyAlias";
     }
 
     public static final class SecureVault {

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/KeyStoreUtil.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/KeyStoreUtil.java
@@ -37,15 +37,16 @@ public class KeyStoreUtil {
      */
     public static Cipher initializeCipher() {
         Cipher cipher;
-        String keyStoreFile = System.getProperty(Constants.PrimaryKeyStore.PRIMARY_KEY_LOCATION_PROPERTY);
-        String keyType = System.getProperty(Constants.PrimaryKeyStore.PRIMARY_KEY_TYPE_PROPERTY);
-        String keyAlias = System.getProperty(Constants.PrimaryKeyStore.PRIMARY_KEY_ALIAS_PROPERTY);
+        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? "Primary" : "Internal");
+        String keyStoreFile = System.getProperty(Constants.KEY_LOCATION_PROPERTY);
+        String keyType = System.getProperty(Constants.KEY_TYPE_PROPERTY);
+        String keyAlias = System.getProperty(Constants.KEY_ALIAS_PROPERTY);
         String password;
         if (System.getProperty(Constants.KEYSTORE_PASSWORD) != null &&
             System.getProperty(Constants.KEYSTORE_PASSWORD).length() > 0) {
             password = System.getProperty(Constants.KEYSTORE_PASSWORD);
         } else {
-            password = Utils.getValueFromConsole("Please Enter Primary KeyStore Password of Carbon Server : ", true);
+            password = Utils.getValueFromConsole("Please Enter " + keyStoreName + " KeyStore Password of Carbon Server : ", true);
         }
         if (password == null) {
             throw new CipherToolException("KeyStore password can not be null");
@@ -71,7 +72,7 @@ public class KeyStoreUtil {
             throw new CipherToolException("Error initializing Cipher ", e);
         }
 
-        System.out.println("\nPrimary KeyStore of Carbon Server is initialized Successfully\n");
+        System.out.println("\n" + keyStoreName + " KeyStore of Carbon Server is initialized Successfully\n");
         return cipher;
     }
 


### PR DESCRIPTION
## Purpose
This PR is to fix wso2/product-is#4071
Currently the cipher-tool will always use PrimaryKeystore to encrypt sensitive information in configuration files. This fix will check for a configured InternalKeystore and use it for encryption else use the PrimaryKeystore.

## Goals
The Cipher Tool will check if there is an InternalKeyStore configured at carbon.xml file.
If an InternalKeyStore is configured it will be used for encrypting sensitive information in configuration files. Else the PrimaryKeyStore configured in carbon.xml file will be used for encrypting sensitive information in configuration files.


