### PR TITLE
Read a keystore file outside product-home

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -235,7 +235,7 @@ public class Utils {
                             Constants.PrimaryKeyStore.KEY_ALIAS_XPATH);
                 }
 
-                keyStoreFile = homeFolder + keyStoreFile.substring((keyStoreFile.indexOf('}')) + 1);
+                keyStoreFile = resolveKeyStorePath(keyStoreFile, homeFolder);
                 System.setProperty(Constants.KEY_LOCATION_PROPERTY, keyStoreFile);
                 String keyStoreName = ((Utils.isPrimaryKeyStore()) ? "Primary" : "Internal");
 
@@ -320,4 +320,20 @@ public class Utils {
     public static boolean isPrimaryKeyStore() {
         return primaryKeyStore;
     }
+
+    /**
+     * Resolve absolute path of the keystore
+     */
+    public static String resolveKeyStorePath(String keyStorePath, String homeFolder) {
+        // Check whether it's a relative path and is inside {carbon.home}.
+        if (keyStorePath.contains("}")) {
+            keyStorePath = getAbsolutePathWithCarbonHome(keyStorePath, homeFolder);
+        }
+        return keyStorePath;
+    }
+    private static String getAbsolutePathWithCarbonHome(String keyStorePath, String homeFolder) {
+        // Append carbon.home location to the relative path.
+        return homeFolder + keyStorePath.substring((keyStorePath.indexOf('}')) + 1);
+    }
+
 }


### PR DESCRIPTION
## Purpose
This PR is to fix wso2/cipher-tool#40
Cipher tool cannot read a keystore file located outside product-home. 

## Goals
With the fix tool is modified to read a keystore file outside the product-home, based on the keystore file path.

## Approach
Tool will append carbon.home location if keystore file's path is a relative path or if it's inside carbon.home directory. If the absolute path of a keystore file is given, it will assign value to the keystore variable without any modifications.
