### PR TITLE
Fixing /wso2/cipher-tool/issues/43-InvalidPathException when running ciphertool in Windows

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -97,6 +97,9 @@ public class Utils {
     public static String getConfigFilePath(String fileName) {
 
         String homeFolder = System.getProperty(Constants.HOME_FOLDER);
+        if (fileName.startsWith(homeFolder)) {
+            fileName = fileName.substring(homeFolder.length(), fileName.length());
+        }
         Path filePath = Paths.get(homeFolder, fileName);
         if (!Files.exists(filePath)) {
             filePath = Paths.get(fileName);


### PR DESCRIPTION
## Purpose
Fixing [wso2/cipher-tool#43](https://github.com/wso2/cipher-tool/issues/43)
The issue was that when running cipher tool with -Dconfigure option, in windows, the keystore file path was read incorrectly. File name had the absolute path of the file, (so had the CARBON_HOME path segment at the beginning). So when resolving Paths.get(homeFolder, fileName) , Path created had the CARBON_HOME segment duplicated at the beginning. 
This was not an issue in linux environments as, Paths.get(homeFolder, fileName); call doesn't throw exceptions given incorrect path.

## Goals
Checking if the filename starts with the CARBON_HOME and if yes, trim that CARBON_HOME segment.
