### PR TITLE
Encrypt non-xml values too via same -Dconfigure command option

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
@@ -147,11 +147,7 @@ public class CipherTool {
                 Utils.loadProperties(System.getProperty(Constants.CIPHER_TEXT_PROPERTY_FILE_PROPERTY));
         for (Object key : cipherTextProperties.keySet()) {
             String passwordAlias = (String) key;
-            if (configFileXpathMap.containsKey(passwordAlias)) {
-                aliasPasswordMap.put(passwordAlias, cipherTextProperties.getProperty(passwordAlias));
-            } else {
-                throw new CipherToolException("XPath value for secret alias '" + passwordAlias + "' cannot be found.");
-            }
+            aliasPasswordMap.put(passwordAlias, cipherTextProperties.getProperty(passwordAlias));
         }
     }
 


### PR DESCRIPTION
## Purpose
The improvement done via this PR is to make Cipher Tool capable of generating the encrypted string for all the secret aliases in cipher-text.properties file without checking the secret alias in cipher-tool.properties file.
Encryption is done by ./bin/ciphertool.sh -Dconfigure command. But as above mentioned, it will throw an error when, running this command, when there is a alias and relevant password mentioned mentioned in cipher-text.properties file in below format, but no relevant entry within cipher-tool.properties file with a path.

`mycustom.secret.alias=[SamplePassword]`

This is an improvement that will be useful to encrypt passwords which are not in xml files.
This fixes wso2/cipher-tool#46
