### PR TITLE
Update Utils.getConfigFilePath() to compare homeFolder with Windows style \

### DIFF
--- a/components/ciphertool/pom.xml
+++ b/components/ciphertool/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ciphertool</groupId>
         <artifactId>ciphertool-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.2-ansos</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/KeyStoreUtil.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/KeyStoreUtil.java
@@ -55,11 +55,14 @@ public class KeyStoreUtil {
         KeyStore primaryKeyStore = getKeyStore(keyStoreFile, password, keyType);
         try {
             Certificate certs = primaryKeyStore.getCertificate(keyAlias);
+			System.out.println("Certificate="+certs.toString());
             String cipherTransformation = System.getProperty(Constants.CIPHER_TRANSFORMATION_SYSTEM_PROPERTY);
             if (cipherTransformation != null) {
                 cipher = Cipher.getInstance(cipherTransformation);
+				System.out.println("\nCipher.getInstance("+cipherTransformation+")");
             } else {
                 cipher = Cipher.getInstance("RSA");
+				System.out.println("\nCipher.getInstance(RSA)");
             }
             cipher.init(Cipher.ENCRYPT_MODE, certs);
         } catch (KeyStoreException e) {

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -101,7 +101,7 @@ public class Utils {
      */
     public static String getConfigFilePath(String fileName) {
 
-        String homeFolder = System.getProperty(Constants.HOME_FOLDER);
+        String homeFolder = System.getProperty(Constants.HOME_FOLDER).replace('\\','/');
         if (fileName.startsWith(homeFolder)) {
             fileName = fileName.substring(homeFolder.length(), fileName.length());
         }

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -101,9 +101,9 @@ public class Utils {
      */
     public static String getConfigFilePath(String fileName) {
 
-        String homeFolder = System.getProperty(Constants.HOME_FOLDER).replace('\\','/');
-        if (fileName.startsWith(homeFolder)) {
-            fileName = fileName.substring(homeFolder.length(), fileName.length());
+        String homeFolder = System.getProperty(Constants.HOME_FOLDER);
+        if (fileName.startsWith(homeFolder) || fileName.startsWith(homeFolder.replace('\\','/'))) {
+            fileName = fileName.substring(homeFolder.length());
         }
         Path filePath = Paths.get(homeFolder, fileName);
         if (!Files.exists(filePath)) {
@@ -112,7 +112,6 @@ public class Utils {
                 throw new CipherToolException("Cannot find file : " + fileName);
             }
         }
-
 
         return filePath.toAbsolutePath().toString();
     }

--- a/components/userstore-ciphertool/pom.xml
+++ b/components/userstore-ciphertool/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.ciphertool</groupId>
         <artifactId>ciphertool-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.2-ansos</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.ciphertool.feature/pom.xml
+++ b/features/org.wso2.ciphertool.feature/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.ciphertool</groupId>
         <artifactId>ciphertool-parent</artifactId>
-        <version>1.1.2-SNAPSHOT</version>
+        <version>1.1.2-ansos</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.wso2.ciphertool</groupId>
     <artifactId>ciphertool-parent</artifactId>
-    <version>1.1.2-SNAPSHOT</version>
+    <version>1.1.2-ansos</version>
     <packaging>pom</packaging>
     <name>WSO2 Cipher Tool - Parent</name>
     <url>http://wso2.org</url>
@@ -111,7 +111,7 @@
     </build>
 
     <properties>
-        <wso2.ciphertool.version>1.1.2-SNAPSHOT</wso2.ciphertool.version>
+        <wso2.ciphertool.version>1.1.2-ansos</wso2.ciphertool.version>
         <maven.bundle.plugin.version>2.3.5</maven.bundle.plugin.version>
         <carbon.p2.plugin.version>1.5.4</carbon.p2.plugin.version>
         <orbit.version.axiom>1.2.11.wso2v6</orbit.version.axiom>


### PR DESCRIPTION
Fix issue when running CipherTool on Windows OS where CARBON_HOME is improperly appended to configuration file path.

Here's a run of ciphertool prior to the fix:

C:\ansos\v65\iam12\wso2is>.\bin\ciphertool -Dconfigure

BUILD SUCCESSFUL
Total time: 3 seconds
Using CARBON_HOME:   C:\ansos\v65\iam12\wso2is
Using JAVA_HOME:    C:\ansos\v65\iam12\java

Encrypting using Internal KeyStore.
{type: JKS, alias: wso2carbon, path: C:/ansos/v65/iam12/wso2is/repository/resources/security/wso2carbon.jks}

Exception in thread "main" java.nio.file.InvalidPathException: Illegal char <:> at index 27: C:\ansos\v65\iam12\wso2is\C:/ansos/v65/iam12/wso2is/repository/resources/security/wso2carbon.jks
        at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
        at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
        at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
        at sun.nio.fs.WindowsPath.parse(WindowsPath.java:94)
        at sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:255)
        at java.nio.file.Paths.get(Paths.java:84)
        at org.wso2.ciphertool.utils.Utils.getConfigFilePath(Utils.java:109)
        at org.wso2.ciphertool.utils.Utils.setSystemProperties(Utils.java:319)
        at org.wso2.ciphertool.CipherTool.initialize(CipherTool.java:93)
        at org.wso2.ciphertool.CipherTool.main(CipherTool.java:52)

The fix is to change the \ in CARBON_HOME to / before testing if file path starts with CARBON_HOME.
