### PR TITLE
Set namespaceAware to false in documentBuilderFactory

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -442,7 +442,7 @@ public class Utils {
             ParserConfigurationException {
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
         documentBuilderFactory.setIgnoringComments(setIgnoreComments);
-        documentBuilderFactory.setNamespaceAware(true);
+        documentBuilderFactory.setNamespaceAware(false);
         documentBuilderFactory.setExpandEntityReferences(false);
         documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();


### PR DESCRIPTION
## Purpose
When invoking ciphertool the following error is occurred,
```
Exception in thread "main" java.lang.NullPointerException
	at org.wso2.ciphertool.utils.Utils.resolveKeyStorePath(Utils.java:347)
	at org.wso2.ciphertool.utils.Utils.setSystemProperties(Utils.java:256)
	at org.wso2.ciphertool.CipherTool.initialize(CipherTool.java:127)
	at org.wso2.ciphertool.CipherTool.main(CipherTool.java:60)
```
This PR fixes that by setting setNamespaceAware to false in documentBuilderFactory. 