### PR TITLE
adding carbon config path as a system parameter in ciphertool.bat file

### DIFF
--- a/features/org.wso2.ciphertool.feature/resources/bin/ciphertool.bat
+++ b/features/org.wso2.ciphertool.feature/resources/bin/ciphertool.bat
@@ -83,6 +83,6 @@ echo Using CARBON_HOME:   %CARBON_HOME%
 echo Using JAVA_HOME:    %JAVA_HOME%
 set _RUNJAVA="%JAVA_HOME%\bin\java"
 
-%_RUNJAVA% %JAVA_OPTS% -Dcarbon.home="%CARBON_HOME%" -cp "%CARBON_CLASSPATH%" org.wso2.ciphertool.CipherTool %*
+%_RUNJAVA% %JAVA_OPTS% -Dcarbon.home="%CARBON_HOME%" -Dcarbon.config.dir.path="%CARBON_HOME%\repository\conf" -cp "%CARBON_CLASSPATH%" org.wso2.ciphertool.CipherTool %*
 endlocal
 :end


### PR DESCRIPTION
## Purpose
Resolves issue : https://github.com/wso2/cipher-tool/issues/57

## Goals
This fix will enable the cipher tool to be used in windows environment with regards to new config model(deployment.toml).

## Approach
adding carbon config path as a system parameter in ciphertool.bat file
