### PR TITLE
Update regex to match any String literal inside []

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
@@ -383,7 +383,7 @@ public class CipherTool {
                 boolean found = false;
                 for (String line : lines) {
                     if (found) {
-                        if (line.matches("[.+]")) {
+                        if (line.matches("\\[.+\\]")) {
                             found = false;
                         } else {
                             StringTokenizer stringTokenizer = new StringTokenizer(line,


### PR DESCRIPTION
## Purpose
Whenever we need to match `[]`, we should escape this like `\\[\\]` (with `\\` in java).

Fixes https://github.com/wso2/micro-integrator/issues/1106
