### PR TITLE
Add property to override default system properties

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
@@ -124,7 +124,10 @@ public class CipherTool {
                 }
             }
         }
-        Utils.setSystemProperties();
+        // Avoid setting system properties if initiated by an external program.
+        if (!Boolean.getBoolean(Constants.SET_EXTERNAL_SYSTEM_PROPERTY)) {
+            Utils.setSystemProperties();
+        }
     }
 
     /**

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
@@ -53,6 +53,8 @@ public class Constants {
     public static final String SECTION_PREFIX = "[";
     public static final String SECTION_SUFFIX = "]";
     public static final String KEY_VALUE_SEPERATOR = "=";
+    // This property will be set to true when external applications need to override the default values
+    public static final String SET_EXTERNAL_SYSTEM_PROPERTY = "external.system.properties";
 
     public static final class PrimaryKeyStore {
         public static final String KEY_LOCATION_XPATH = "//Server/Security/KeyStore/Location";


### PR DESCRIPTION
## Purpose
> Add a property to allow external programs to set system properties without using ciphertool default values.

