### PR TITLE
Skip commented lines in toml when running cipher tool

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
@@ -385,7 +385,8 @@ public class CipherTool {
                  FileOutputStream(Utils.getDeploymentFilePath()), StandardCharsets.UTF_8))) {
                 boolean found = false;
                 for (String line : lines) {
-                    if (found) {
+                    boolean isLineCommented = line.trim().matches("^#.*");
+                    if (found && !isLineCommented) {
                         if (line.matches("\\[.+\\]")) {
                             found = false;
                         } else {


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

With commented out values in deployment.toml, Ciphertool is not working properly.
Resolves https://github.com/wso2/micro-integrator/issues/1769

Tested the following scenarios and verified that is working.

Scenario 1  :white_check_mark:

```
[server]
hostname = "localhost"
hot_deployment = "true"

[secrets]
testkey1 = "[wso2carbon]"
```

Scenario 2  :white_check_mark:

```
[server]
hostname = "localhost"
hot_deployment = "true"

[secrets]
testkey1 = "[wso2carbon]"

# [secrets]
# testkey1 = "[wso2carbon]"
```

Scenario 3  :white_check_mark:

```
[server]
hostname = "localhost"
hot_deployment = "true"

# [user_store]
# type = "read_only_ldap"

[secrets]
testkey1 = "[wso2carbon]"

# [secrets]
# testkey1 = "[wso2carbon]"

[user_store]
type = "read_only_ldap"
```

Scenario 4  :white_check_mark:

```
[server]
hostname = "localhost"
hot_deployment = "true"

[secrets]
testkey1 = "[wso2carbon]"
# testkey2 = "[wso2carbon1]"
testkey2 = "[wso2carbon]"
```

Scenario 5  :white_check_mark:

```
[server]
hostname = "localhost"
hot_deployment = "true"

[secrets]
testkey1 = "[wso2carbon]"
# testkey2 = "[wso2carbon1]"
testkey3 = "[wso2carbon3]"
    # testkey4 = "[wso2carbon4]"
```
