### PR TITLE
Resolves naming conflict in reading internal keystore in deployment.toml

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
@@ -29,6 +29,7 @@ public class Constants {
     public static final String REPOSITORY_DIR = "repository";
     public static final String CONF_DIR = "conf";
     public static final String SECURITY_DIR = "security";
+    public static final String RESOURCES_DIR = "resources";
 
     public static final String CARBON_CONFIG_FILE = "carbon.xml";
     public static final String CIPHER_TEXT_PROPERTY_FILE = "cipher-text.properties";

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -365,6 +365,13 @@ public class Utils {
         // Check whether it's a relative path and is inside {carbon.home}.
         if (keyStorePath.contains("}")) {
             keyStorePath = getAbsolutePathWithCarbonHome(keyStorePath, homeFolder);
+        } else if (!keyStorePath.startsWith(homeFolder)) {
+            if (keyStorePath.contains(Constants.REPOSITORY_DIR + "/" + Constants.RESOURCES_DIR + "/" + Constants.SECURITY_DIR)) {
+                keyStorePath = Paths.get(homeFolder, keyStorePath).toString();
+            } else {
+                keyStorePath = Paths.get(homeFolder, Constants.REPOSITORY_DIR,
+                        Constants.RESOURCES_DIR, Constants.SECURITY_DIR, keyStorePath).toString();
+            }
         }
         return keyStorePath;
     }


### PR DESCRIPTION
## Overview
MI 4.1.0 gives the priority for deployment.toml file over carbon.xml when executing the cipher-tool script.
Since MI uses Path-based parameters when fetching from deployment.toml and Ciphertool uses File-based parameters,
there is a naming conflict.