### PR TITLE
Remove SHA1 default usage

### DIFF
--- a/components/userstore-ciphertool/src/main/java/org/wso2/ciphertool/userstore/Encryptor.java
+++ b/components/userstore-ciphertool/src/main/java/org/wso2/ciphertool/userstore/Encryptor.java
@@ -45,7 +45,7 @@ public class Encryptor {
     private static final char[] HEX_CHARACTERS = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
     public static final String CRYPTO_PROVIDER_BC = "BC";
     private static final String DEFAULT_CRYPTO_ALGORITHM = "RSA";
-    private static final String DIGEST_ALGORITHM = "SHA-1";
+    private static final String DIGEST_ALGORITHM = "SHA-256";
 
     public String encrypt(String cleartext, CryptoContext cryptoContext) throws Exception {
 


### PR DESCRIPTION
### Proposed changes in this pull request

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the default usage to SHA256 when creating cipher text.

### Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

### Related PRs

- PR https://github.com/wso2/carbon-identity-framework/pull/4567
- PR https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/162
- PR https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/136
- PR https://github.com/wso2-extensions/identity-metadata-saml2/pull/85
- PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2076
- PR https://github.com/wso2/cipher-tool/pull/78
- PR https://github.com/wso2/carbon-kernel/pull/3574
- PR https://github.com/wso2-extensions/identity-user-account-association/pull/47
- PR https://github.com/wso2-enterprise/asgardeo-website/pull/639
- PR https://github.com/wso2-extensions/identity-governance/pull/707
- PR https://github.com/wso2-extensions/identity-inbound-auth-openid/pull/92
- PR https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/173
- PR https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/157

### Documentation

- PR https://github.com/wso2/docs-is/pull/3717
