### PR TITLE
Improve ciphertool to read default.json file path

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
@@ -36,6 +36,7 @@ public class Constants {
     public static final String CIPHER_TOOL_PROPERTY_FILE = "cipher-tool.properties";
     public static final String SECRET_PROPERTY_FILE = "secret-conf.properties";
     public static final String DEFAULT_JSON_FILE = "default.json";
+    public static final String DEFAULT_JSON_DIR_PATH = "default.json.dir.path";
     public static final String DEPLOYMENT_TOML_FILE = "deployment.toml";
     public static final String DEPLOYMENT_CONFIG_FILE_PATH = "deployment.config.file.path";
     public static final String CARBON_CONFIG_DIR_PATH = "carbon.config.dir.path";

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -461,15 +461,19 @@ public class Utils {
      */
     public static Path getDefaultJSONFilePath() {
 
-        String homeFolder = System.getProperty(Constants.CARBON_HOME);
-        Path filePath = null;
-        try {
-            filePath = Paths.get(homeFolder, Constants.REPOSITORY_DIR,
-                    Constants.RESOURCES_DIR, Constants.CONF_DIR, Constants.DEFAULT_JSON_FILE);
-        } catch (InvalidPathException e) {
-            System.err.println("Error while resolving the default.json file path" + e.toString());
+        String defaultJsonDirPath = System.getProperty(Constants.DEFAULT_JSON_DIR_PATH);
+        if (StringUtils.isEmpty(defaultJsonDirPath)) {
+            String homeFolder = System.getProperty(Constants.CARBON_HOME);
+            Path filePath = null;
+            try {
+                filePath = Paths.get(homeFolder, Constants.REPOSITORY_DIR,
+                        Constants.RESOURCES_DIR, Constants.CONF_DIR, Constants.DEFAULT_JSON_FILE);
+            } catch (InvalidPathException e) {
+                System.err.println("Error while resolving the default.json file path" + e.toString());
+            }
+            return filePath;
         }
-        return filePath;
+        return Paths.get(defaultJsonDirPath, Constants.DEFAULT_JSON_FILE);
     }
 
     /**


### PR DESCRIPTION
Resolves https://github.com/wso2/api-manager/issues/1721

From a previous improvement, default.json is being read when running the ciphertool. Because the location of the default.json is not configurable, the following error is thrown when running the ciphertool.

`Error parsing file wso2mi-dashboard-4.2.0/repository/resources/conf/default.json java.nio.file.NoSuchFileException: wso2mi-dashboard/4.2.0/wso2mi-dashboard-4.2.0/repository/resources/conf/default.json`

This PR brings improvement to configure the location of the default.json file via a System property.