### PR TITLE
Revert "Remove SHA1 default usage"

### DIFF
--- a/components/userstore-ciphertool/src/main/java/org/wso2/ciphertool/userstore/Encryptor.java
+++ b/components/userstore-ciphertool/src/main/java/org/wso2/ciphertool/userstore/Encryptor.java
@@ -45,7 +45,7 @@ public class Encryptor {
     private static final char[] HEX_CHARACTERS = new char[]{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
     public static final String CRYPTO_PROVIDER_BC = "BC";
     private static final String DEFAULT_CRYPTO_ALGORITHM = "RSA";
-    private static final String DIGEST_ALGORITHM = "SHA-256";
+    private static final String DIGEST_ALGORITHM = "SHA-1";
 
     public String encrypt(String cleartext, CryptoContext cryptoContext) throws Exception {
 


### PR DESCRIPTION
Reverts wso2/cipher-tool#78 since update was intended for 1.x.x