### PR TITLE
Add secretRepositories.file.algorithm to secret-conf.properties file

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
@@ -95,6 +95,7 @@ public class Constants {
         public static final String SECRET_REPOSITORIES = "secretRepositories";
         public static final String CARBON_SECRET_PROVIDER = "carbon.secretProvider";
         public static final String SECRET_FILE_PROVIDER = "secretRepositories.file.provider";
+        public static final String SECRET_FILE_ALGORITHM= "secretRepositories.file.algorithm";
         public static final String SECRET_FILE_BASE_PROVIDER_CLASS =
                 "org.wso2.securevault.secret.repository.FileBaseSecretRepositoryProvider";
         public static final String SECRET_FILE_LOCATION = "secretRepositories.file.location";

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -246,6 +246,8 @@ public class Utils {
                 .setProperty(Constants.SecureVault.KEYSTORE_KEY_PASSWORD, Constants.SecureVault.IDENTITY_KEY_PASSWORD);
         properties.setProperty(Constants.SecureVault.KEYSTORE_KEY_SECRET_PROVIDER,
                                Constants.SecureVault.CARBON_DEFAULT_SECRET_PROVIDER);
+        properties.setProperty(Constants.SecureVault.SECRET_FILE_ALGORITHM,
+                        System.getProperty(Constants.CIPHER_TRANSFORMATION_SYSTEM_PROPERTY));
 
         writeToPropertyFile(properties, System.getProperty(Constants.SECRET_PROPERTY_FILE_PROPERTY));
 


### PR DESCRIPTION
When a user sets a different encryption algorithm using, -Dorg.wso2.CipherTransformation, the secret-conf.properties file has to be uptated accordingly. Otherwise decryption will fail.

Port: https://github.com/wso2/cipher-tool/pull/62