### PR TITLE
Fix NPE when org.wso2.CipherTransformation is not provided

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -246,8 +246,10 @@ public class Utils {
                 .setProperty(Constants.SecureVault.KEYSTORE_KEY_PASSWORD, Constants.SecureVault.IDENTITY_KEY_PASSWORD);
         properties.setProperty(Constants.SecureVault.KEYSTORE_KEY_SECRET_PROVIDER,
                                Constants.SecureVault.CARBON_DEFAULT_SECRET_PROVIDER);
-        properties.setProperty(Constants.SecureVault.SECRET_FILE_ALGORITHM,
-                        System.getProperty(Constants.CIPHER_TRANSFORMATION_SYSTEM_PROPERTY));
+        if (StringUtils.isNotBlank(System.getProperty(Constants.CIPHER_TRANSFORMATION_SYSTEM_PROPERTY))) {
+            properties.setProperty(Constants.SecureVault.SECRET_FILE_ALGORITHM,
+                    System.getProperty(Constants.CIPHER_TRANSFORMATION_SYSTEM_PROPERTY));
+        }
 
         writeToPropertyFile(properties, System.getProperty(Constants.SECRET_PROPERTY_FILE_PROPERTY));
 


### PR DESCRIPTION
## Purpose
The ciphertool causes NPE when `org.wso2.CipherTransformation` system property is not defined. This is happening due to https://github.com/wso2/cipher-tool/pull/86