### PR TITLE
Add symmetric encryption for CipherTool

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
@@ -39,9 +39,17 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import javax.xml.xpath.*;
-import java.io.*;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -50,7 +58,12 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringTokenizer;
 
 import static org.wso2.ciphertool.utils.Utils.getSecuredDocumentBuilder;
 
@@ -85,6 +98,9 @@ public class CipherTool {
             Utils.writeToSecureConfPropertyFile();
         } else if (Constants.TRUE.equals(System.getProperty(Constants.ROTATE))) {
             String oldAlias  = System.getProperty(Constants.OLD_KEY_ALIAS);
+            if (StringUtils.isBlank(oldAlias)) {
+                throw new CipherToolException(Constants.OLD_KEY_ALIAS + " parameter is required for key rotate mode.");
+            }
             CipherMode oldCipherMode = isSymmetricKey(oldAlias, keyStore)
                     ? new SymmetricCipher(keyStore, oldAlias) : new AsymmetricCipher(keyStore, oldAlias);
             File deploymentTomlFile = new File(Utils.getDeploymentFilePath());

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
@@ -99,7 +99,8 @@ public class CipherTool {
         } else if (Constants.TRUE.equals(System.getProperty(Constants.ROTATE))) {
             String oldAlias  = System.getProperty(Constants.OLD_KEY_ALIAS);
             if (StringUtils.isBlank(oldAlias)) {
-                throw new CipherToolException(Constants.OLD_KEY_ALIAS + " parameter is required for key rotate mode.");
+                throw new CipherToolException(
+                        Constants.Error.PARAMETER_REQUIRED_FOR_ROTATE_MODE.getMessage(Constants.OLD_KEY_ALIAS));
             }
             CipherMode oldCipherMode = isSymmetricKey(oldAlias, keyStore)
                     ? new SymmetricCipher(keyStore, oldAlias) : new AsymmetricCipher(keyStore, oldAlias);
@@ -111,7 +112,6 @@ public class CipherTool {
                     String oldEncryptedValue = Utils.getEncryptedValue(entry.getValue());
                     if (StringUtils.isNotEmpty(oldEncryptedValue)) {
                         String value = oldCipherMode.doDecryption(oldEncryptedValue);
-                        secretMap.replace(key, value);
                         if (StringUtils.isNotEmpty(value)) {
                             String encryptedValue = cipherMode.doEncryption(value);
                             secretMap.replace(key, encryptedValue);
@@ -120,7 +120,7 @@ public class CipherTool {
                 }
                 updateDeploymentConfigurationWithEncryptedKeys(secretMap);
             } else {
-                throw new CipherToolException(deploymentTomlFile + " file not found.");
+                throw new CipherToolException(Constants.Error.TOML_NOT_FOUND.getMessage(deploymentTomlFile));
             }
             Utils.writeToSecureConfPropertyFile();
         } else if (Constants.TRUE.equals(System.getProperty(Constants.CHANGE))) {

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
@@ -139,6 +139,8 @@ public class CipherTool {
 
         System.out.println("\t-Dchange\t\t This option would allow user to change the specific password which has " +
                            "been secured\n");
+        System.out.println("\t-Dsymmetric\t\t This option would allow user to use symmetric encryption for creating " +
+                "encrypted values.\n");
         System.out.println("\t-Dpassword=<password>\t This option would allow user to provide the password as a " +
                            "command line argument. NOTE: Providing the password in command line arguments list is " +
                            "not recommended.\n");

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
@@ -24,6 +24,7 @@ import org.wso2.ciphertool.cipher.CipherFactory;
 import org.wso2.ciphertool.cipher.CipherMode;
 import org.wso2.ciphertool.exception.CipherToolException;
 import org.wso2.ciphertool.utils.Constants;
+import org.wso2.ciphertool.utils.KeyStoreUtil;
 import org.wso2.ciphertool.utils.Utils;
 import org.xml.sax.SAXException;
 
@@ -41,6 +42,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.KeyStore;
 import java.util.*;
 
 import static org.wso2.ciphertool.utils.Utils.getSecuredDocumentBuilder;
@@ -53,7 +55,8 @@ public class CipherTool {
     public static void main(String[] args) {
 
         initialize(args);
-        CipherMode cipherMode = CipherFactory.createCipher();
+        KeyStore keyStore = KeyStoreUtil.getKeyStore();
+        CipherMode cipherMode = CipherFactory.createCipher(keyStore);
         if (Constants.TRUE.equals(System.getProperty(Constants.CONFIGURE))) {
             File deploymentTomlFile = new File(Utils.getDeploymentFilePath());
             if (deploymentTomlFile.exists()) {

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
@@ -467,6 +467,14 @@ public class CipherTool {
         }
     }
 
+    /**
+     * Checks if the key associated with the given alias in the provided keystore is a symmetric key.
+     *
+     * @param keyAlias the alias of the key to be checked.
+     * @param keystore the keystore containing the key.
+     * @return true if the key is a symmetric key, false otherwise.
+     * @throws CipherToolException if there is an error initializing the cipher or retrieving the key
+     */
     private static boolean isSymmetricKey(String keyAlias, KeyStore keystore) {
         try {
             Key key = keystore.getKey(keyAlias, KeyStoreUtil.getKeystorePassword().toCharArray());

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/AsymmetricCipher.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/AsymmetricCipher.java
@@ -44,8 +44,6 @@ public class AsymmetricCipher implements CipherMode {
     private final String keyAlias;
     private final KeyStore keyStore;
     private final Cipher cipher;
-    private static final String CIPHER_INIT_ERROR_MESSAGE = "Error initializing Cipher.";
-    private static final String GET_KEY_ERROR_MESSAGE = "Error retrieving key associated with alias : ";
 
     public AsymmetricCipher(KeyStore keyStore, String keyAlias) {
 
@@ -57,7 +55,7 @@ public class AsymmetricCipher implements CipherMode {
         try {
             this.cipher = Cipher.getInstance(algorithm);
         } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
-            throw new CipherToolException(CIPHER_INIT_ERROR_MESSAGE, e);
+            throw new CipherToolException(Constants.Error.CIPHER_INIT_ERROR_MESSAGE.getMessage(), e);
         }
     }
 
@@ -79,13 +77,19 @@ public class AsymmetricCipher implements CipherMode {
             Certificate certs = this.keyStore.getCertificate(this.keyAlias);
             cipher.init(Cipher.ENCRYPT_MODE, certs);
         } catch (KeyStoreException e) {
-            throw new CipherToolException(GET_KEY_ERROR_MESSAGE + this.keyAlias, e);
+            throw new CipherToolException(Constants.Error.GET_KEY_ERROR_MESSAGE.getMessage(this.keyAlias), e);
         } catch (InvalidKeyException e) {
             throw new CipherToolException("The provided public cert is invalid.", e);
         }
         return Utils.doEncryption(cipher, plainText);
     }
 
+    /**
+     * Decrypt encrypted text using encryption.
+     *
+     * @param cipherText Encrypted password.
+     * @return Plain text password.
+     */
     @Override
     public String doDecryption(String cipherText) {
 
@@ -95,7 +99,7 @@ public class AsymmetricCipher implements CipherMode {
         }  catch (NoSuchAlgorithmException | InvalidKeyException e) {
             throw new CipherToolException("The provided private key is invalid.", e);
         } catch (KeyStoreException | UnrecoverableKeyException e) {
-            throw new CipherToolException(GET_KEY_ERROR_MESSAGE + this.keyAlias, e);
+            throw new CipherToolException(Constants.Error.GET_KEY_ERROR_MESSAGE.getMessage(this.keyAlias), e);
         }
         return Utils.doDecryption(cipher, Base64.getDecoder().decode(cipherText.getBytes(StandardCharsets.UTF_8)));
     }

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/AsymmetricCipher.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/AsymmetricCipher.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.ciphertool.cipher;
+
+import org.wso2.ciphertool.utils.KeyStoreUtil;
+import org.wso2.ciphertool.utils.Utils;
+
+import javax.crypto.Cipher;
+
+public class AsymmetricCipher implements CipherMode {
+
+    private final Cipher cipher;
+
+    public AsymmetricCipher() {
+
+        this.cipher = KeyStoreUtil.initializeCipher();
+    }
+
+    /**
+     * Encrypt plain text using asymmetric encryption.
+     *
+     * @param plainText Plain text password.
+     * @return Encrypted password.
+     */
+    @Override
+    public String doEncryption(String plainText) {
+
+        return Utils.doEncryption(cipher, plainText);
+    }
+}

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/AsymmetricCipher.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/AsymmetricCipher.java
@@ -22,6 +22,9 @@ import org.wso2.ciphertool.utils.Utils;
 
 import javax.crypto.Cipher;
 
+/**
+ * Provides methods for encryption and decryption using asymmetric key algorithms.
+ */
 public class AsymmetricCipher implements CipherMode {
 
     private final Cipher cipher;

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherFactory.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherFactory.java
@@ -19,6 +19,8 @@ package org.wso2.ciphertool.cipher;
 
 import org.wso2.ciphertool.utils.Constants;
 
+import java.security.KeyStore;
+
 /**
  * The CipherFactory class provides a static method to create either a SymmetricCipher or AsymmetricCipher
  * based on a system property.
@@ -34,11 +36,12 @@ public class CipherFactory {
      *
      * @return An instance of {@code CipherMode}, either {@code SymmetricCipher} or {@code AsymmetricCipher}.
      */
-    public static CipherMode createCipher() {
+    public static CipherMode createCipher(KeyStore keyStore) {
+
         if (Constants.TRUE.equals(System.getProperty(Constants.SYMMETRIC))) {
-            return new SymmetricCipher();
+            return new SymmetricCipher(keyStore);
         } else {
-            return new AsymmetricCipher();
+            return new AsymmetricCipher(keyStore);
         }
     }
 

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherFactory.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.ciphertool.cipher;
+
+import org.wso2.ciphertool.utils.Constants;
+
+public class CipherFactory {
+
+    private CipherFactory() {
+
+    }
+
+    public static CipherMode createCipher() {
+        if (Constants.TRUE.equals(System.getProperty(Constants.SYMMETRIC))) {
+            return new SymmetricCipher();
+        } else {
+            return new AsymmetricCipher();
+        }
+    }
+
+}

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherFactory.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherFactory.java
@@ -19,12 +19,21 @@ package org.wso2.ciphertool.cipher;
 
 import org.wso2.ciphertool.utils.Constants;
 
+/**
+ * The CipherFactory class provides a static method to create either a SymmetricCipher or AsymmetricCipher
+ * based on a system property.
+ */
 public class CipherFactory {
 
     private CipherFactory() {
 
     }
 
+    /**
+     * Creates an instance of CipherMode based on the {@code Constants.SYMMETRIC} system property.
+     *
+     * @return An instance of {@code CipherMode}, either {@code SymmetricCipher} or {@code AsymmetricCipher}.
+     */
     public static CipherMode createCipher() {
         if (Constants.TRUE.equals(System.getProperty(Constants.SYMMETRIC))) {
             return new SymmetricCipher();

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherMode.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherMode.java
@@ -17,6 +17,9 @@
  */
 package org.wso2.ciphertool.cipher;
 
+/**
+ * The interface for providing methods for encrypting and decrypting text.
+ */
 public interface CipherMode {
 
     /**

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherMode.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherMode.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.ciphertool.cipher;
+
+public interface CipherMode {
+
+    /**
+     * Encrypt plain text using encryption.
+     *
+     * @param plainText Plain text password.
+     * @return Encrypted password.
+     */
+    String doEncryption(String plainText);
+}

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherMode.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherMode.java
@@ -26,4 +26,12 @@ public interface CipherMode {
      * @return Encrypted password.
      */
     String doEncryption(String plainText);
+
+    /**
+     * Decrypt cipher text into plain text using decryption.
+     *
+     * @param cipherText Cipher text.
+     * @return Decrypted plain text.
+     */
+    String doDecryption(String cipherText);
 }

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.ciphertool.cipher;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+import org.wso2.ciphertool.exception.CipherToolException;
+import org.wso2.ciphertool.utils.Constants;
+import org.wso2.ciphertool.utils.KeyStoreUtil;
+import org.wso2.ciphertool.utils.Utils;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.UnrecoverableKeyException;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.GCMParameterSpec;
+
+public class SymmetricCipher implements CipherMode {
+
+    private static final int GCM_IV_LENGTH = 128;
+    private static final int GCM_TAG_LENGTH = 128;
+    private final Key secretKey;
+
+    public SymmetricCipher() {
+
+        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? "Primary" : "Internal");
+        String keyStoreFile = System.getProperty(Constants.KEY_LOCATION_PROPERTY);
+        String keyType = System.getProperty(Constants.KEY_TYPE_PROPERTY);
+        String password = StringUtils.isNotBlank(System.getProperty(Constants.KEYSTORE_PASSWORD))
+                ? System.getProperty(Constants.KEYSTORE_PASSWORD)
+                : Utils.getValueFromConsole("Please Enter " + keyStoreName + " KeyStore Password of Carbon Server : ", true);
+        if (StringUtils.isBlank(password)) {
+            throw new CipherToolException("KeyStore password can not be null");
+        }
+        KeyStore keyStore = KeyStoreUtil.getKeyStore(keyStoreFile, password, keyType);
+        String keyAlias = System.getProperty(Constants.KEY_ALIAS_PROPERTY);
+        try {
+            this.secretKey = keyStore.getKey(keyAlias, password.toCharArray());
+            if (this.secretKey == null) {
+                throw new KeyStoreException("Error retrieving key associated with alias : " + keyAlias);
+            }
+        } catch (KeyStoreException | NoSuchAlgorithmException e) {
+            throw new CipherToolException("Error initializing Keystore ", e);
+        } catch (UnrecoverableKeyException e) {
+            throw new CipherToolException("Error retrieving key associated with alias : " + keyAlias, e);
+        }
+        System.out.println("\n" + keyStoreName + " KeyStore of Carbon Server is initialized Successfully\n");
+    }
+
+    /**
+     * Encrypt plain text using symmetric encryption.
+     *
+     * @param plainText Plain text password.
+     * @return Encrypted password.
+     */
+    @Override
+    public String doEncryption(String plainText) {
+
+        Cipher cipher;
+        String cipherTransformation = System.getProperty(Constants.CIPHER_TRANSFORMATION_SYSTEM_PROPERTY);
+        cipherTransformation = StringUtils.isNotBlank(cipherTransformation)
+                ? cipherTransformation : Constants.AES_GCM_NO_PADDING;
+        try {
+            cipher = Cipher.getInstance(cipherTransformation);
+            if (Constants.AES_GCM_NO_PADDING.equals(cipherTransformation)) {
+                byte[] iv = getInitializationVector();
+                cipher.init(Cipher.ENCRYPT_MODE, this.secretKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+                String cipherText = Utils.doEncryption(cipher, plainText);
+                return createSelfContainedCiphertextWithGCMMode(cipherText, iv);
+            } else {
+                cipher.init(Cipher.ENCRYPT_MODE, this.secretKey);
+                return Utils.doEncryption(cipher, plainText);
+            }
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException |
+                 InvalidAlgorithmParameterException e) {
+            throw new CipherToolException("Error initializing Cipher ", e);
+        }
+    }
+
+    private byte[] getInitializationVector() {
+
+        byte[] iv = new byte[GCM_IV_LENGTH];
+        SecureRandom secureRandom = new SecureRandom();
+        secureRandom.nextBytes(iv);
+        return iv;
+    }
+
+
+    private String createSelfContainedCiphertextWithGCMMode(String originalCipher, byte[] iv) {
+
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("cipherText", originalCipher);
+        jsonObject.addProperty("iv", Base64.getEncoder().encodeToString(iv));
+        return Base64.getEncoder().encodeToString(new Gson().toJson(jsonObject).getBytes());
+    }
+}

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
@@ -132,25 +132,45 @@ public class SymmetricCipher implements CipherMode {
         }
     }
 
-    private JsonObject getJsonObject(String encryptedText) {
+    /**
+     * Decodes the given Base64 encoded string into a JsonObject.
+     *
+     * @param encodedCiphertext Base64 encoded string representing the JSON object.
+     * @return                  The parsed JSON object.
+     * @throws CipherToolException if the provided string is not a valid JSON
+     */
+    private JsonObject getJsonObject(String encodedCiphertext) {
 
         try {
-            String jsonString = new String(Base64.getDecoder().decode(encryptedText));
+            String jsonString = new String(Base64.getDecoder().decode(encodedCiphertext));
             return JsonParser.parseString(jsonString).getAsJsonObject();
         } catch (JsonSyntaxException e) {
             throw new CipherToolException(Constants.Error.INVALID_JSON.getMessage());
         }
     }
 
-    private byte[] getValueFromJson(JsonObject jsonObject, String value) {
+    /**
+     * Retrieves the value associated with the specified key from the given JsonObject and decodes it from Base64.
+     *
+     * @param jsonObject    JSON object containing the key-value pair.
+     * @param key           Key for the value to be retrieved.
+     * @return The decoded value
+     * @throws CipherToolException if the key is not found in the JsonObject
+     */
+    private byte[] getValueFromJson(JsonObject jsonObject, String key) {
 
-        JsonElement jsonElement = jsonObject.get(value);
+        JsonElement jsonElement = jsonObject.get(key);
         if (jsonElement == null) {
-            throw new CipherToolException(Constants.Error.JSON_VALUE_NOT_FOUND.getMessage(value));
+            throw new CipherToolException(Constants.Error.JSON_VALUE_NOT_FOUND.getMessage(key));
         }
         return Base64.getDecoder().decode(jsonElement.getAsString().getBytes(StandardCharsets.UTF_8));
     }
 
+    /**
+     * Generates a new initialization vector (IV) for GCM encryption.
+     *
+     * @return the generated IV as a byte array
+     */
     private byte[] getInitializationVector() {
 
         byte[] iv = new byte[GCM_IV_LENGTH];
@@ -160,10 +180,17 @@ public class SymmetricCipher implements CipherMode {
     }
 
 
-    private String createSelfContainedCiphertextWithGCMMode(String originalCipher, byte[] iv) {
+    /**
+     * Creates a self-contained ciphertext with GCM mode.
+     *
+     * @param ciphertext    Original ciphertext to be included in the JSON object.
+     * @param iv            Initialization vector.
+     * @return Base64 encoded JSON object containing the ciphertext and IV.
+     */
+    private String createSelfContainedCiphertextWithGCMMode(String ciphertext, byte[] iv) {
 
         JsonObject jsonObject = new JsonObject();
-        jsonObject.addProperty(Constants.CIPHERTEXT, originalCipher);
+        jsonObject.addProperty(Constants.CIPHERTEXT, ciphertext);
         jsonObject.addProperty(Constants.IV, Base64.getEncoder().encodeToString(iv));
         return Base64.getEncoder().encodeToString(new Gson().toJson(jsonObject).getBytes());
     }

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
@@ -19,7 +19,7 @@ package org.wso2.ciphertool.cipher;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.wso2.ciphertool.exception.CipherToolException;
 import org.wso2.ciphertool.utils.Constants;
 import org.wso2.ciphertool.utils.KeyStoreUtil;
@@ -47,35 +47,31 @@ public class SymmetricCipher implements CipherMode {
     private static final int GCM_IV_LENGTH = 128;
     private static final int GCM_TAG_LENGTH = 128;
     private final Key secretKey;
+    private final Cipher cipher;
+    private final String algorithm;
 
-    public SymmetricCipher() {
+    public SymmetricCipher(KeyStore keyStore) {
 
-        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? "Primary" : "Internal");
-        String keyStoreFile = System.getProperty(Constants.KEY_LOCATION_PROPERTY);
-        String keyType = System.getProperty(Constants.KEY_TYPE_PROPERTY);
-        String password = StringUtils.isNotBlank(System.getProperty(Constants.KEYSTORE_PASSWORD))
-                ? System.getProperty(Constants.KEYSTORE_PASSWORD)
-                : Utils.getValueFromConsole("Please Enter " + keyStoreName + " KeyStore Password of Carbon Server : ", true);
-        if (StringUtils.isBlank(password)) {
-            throw new CipherToolException("KeyStore password can not be null");
-        }
-        KeyStore keyStore = KeyStoreUtil.getKeyStore(keyStoreFile, password, keyType);
+        String cipherTransformation = System.getProperty(Constants.CIPHER_TRANSFORMATION_SYSTEM_PROPERTY);
+        this.algorithm = StringUtils.isNotBlank(cipherTransformation)
+                ? cipherTransformation : Constants.AES_GCM_NO_PADDING;
+        String password = KeyStoreUtil.getKeystorePassword();
         String keyAlias = System.getProperty(Constants.KEY_ALIAS_PROPERTY);
         try {
             this.secretKey = keyStore.getKey(keyAlias, password.toCharArray());
             if (this.secretKey == null) {
                 throw new KeyStoreException("Error retrieving key associated with alias : " + keyAlias);
             }
-        } catch (KeyStoreException | NoSuchAlgorithmException e) {
+            this.cipher = Cipher.getInstance(this.algorithm);
+        } catch (KeyStoreException | NoSuchAlgorithmException | NoSuchPaddingException e) {
             throw new CipherToolException("Error initializing Keystore ", e);
         } catch (UnrecoverableKeyException e) {
             throw new CipherToolException("Error retrieving key associated with alias : " + keyAlias, e);
         }
-        System.out.println("\n" + keyStoreName + " KeyStore of Carbon Server is initialized Successfully\n");
     }
 
     /**
-     * Encrypt plain text using symmetric encryption.
+     * Encrypt plain text using encryption.
      *
      * @param plainText Plain text password.
      * @return Encrypted password.
@@ -83,13 +79,8 @@ public class SymmetricCipher implements CipherMode {
     @Override
     public String doEncryption(String plainText) {
 
-        Cipher cipher;
-        String cipherTransformation = System.getProperty(Constants.CIPHER_TRANSFORMATION_SYSTEM_PROPERTY);
-        cipherTransformation = StringUtils.isNotBlank(cipherTransformation)
-                ? cipherTransformation : Constants.AES_GCM_NO_PADDING;
         try {
-            cipher = Cipher.getInstance(cipherTransformation);
-            if (Constants.AES_GCM_NO_PADDING.equals(cipherTransformation)) {
+            if (Constants.AES_GCM_NO_PADDING.equals(this.algorithm)) {
                 byte[] iv = getInitializationVector();
                 cipher.init(Cipher.ENCRYPT_MODE, this.secretKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
                 String cipherText = Utils.doEncryption(cipher, plainText);
@@ -98,8 +89,7 @@ public class SymmetricCipher implements CipherMode {
                 cipher.init(Cipher.ENCRYPT_MODE, this.secretKey);
                 return Utils.doEncryption(cipher, plainText);
             }
-        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException |
-                 InvalidAlgorithmParameterException e) {
+        } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
             throw new CipherToolException("Error initializing Cipher ", e);
         }
     }

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
@@ -39,6 +39,9 @@ import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.GCMParameterSpec;
 
+/**
+ * Provides methods for encryption and decryption using symmetric key algorithms.
+ */
 public class SymmetricCipher implements CipherMode {
 
     private static final int GCM_IV_LENGTH = 128;

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
@@ -63,13 +63,13 @@ public class SymmetricCipher implements CipherMode {
         try {
             this.secretKey = keyStore.getKey(keyAlias, password.toCharArray());
             if (this.secretKey == null) {
-                throw new KeyStoreException(Constants.Error.GET_KEY_ERROR_MESSAGE + keyAlias);
+                throw new KeyStoreException(Constants.Error.GET_KEY_ERROR_MESSAGE.getMessage(keyAlias));
             }
             this.cipher = Cipher.getInstance(this.algorithm);
         } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
             throw new CipherToolException(Constants.Error.CIPHER_INIT_ERROR_MESSAGE.getMessage(), e);
         } catch (KeyStoreException | UnrecoverableKeyException e) {
-            throw new CipherToolException(Constants.Error.GET_KEY_ERROR_MESSAGE + keyAlias, e);
+            throw new CipherToolException(Constants.Error.GET_KEY_ERROR_MESSAGE.getMessage(keyAlias), e);
         }
     }
 

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
@@ -53,6 +53,9 @@ public class SymmetricCipher implements CipherMode {
     private final Key secretKey;
     private final Cipher cipher;
     private final String algorithm;
+    private static final String GET_KEY_ERROR_MESSAGE = "Error retrieving key associated with alias : ";
+    private static final String CIPHER_INIT_ERROR_MESSAGE = "Error initializing Cipher.";
+    private static final String INVALID_SECRET_ERROR_MESSAGE = "The provided secret key is invalid.";
 
     public SymmetricCipher(KeyStore keyStore, String keyAlias) {
 
@@ -63,13 +66,13 @@ public class SymmetricCipher implements CipherMode {
         try {
             this.secretKey = keyStore.getKey(keyAlias, password.toCharArray());
             if (this.secretKey == null) {
-                throw new KeyStoreException("Error retrieving key associated with alias : " + keyAlias);
+                throw new KeyStoreException(GET_KEY_ERROR_MESSAGE + keyAlias);
             }
             this.cipher = Cipher.getInstance(this.algorithm);
-        } catch (KeyStoreException | NoSuchAlgorithmException | NoSuchPaddingException e) {
-            throw new CipherToolException("Error initializing Keystore ", e);
-        } catch (UnrecoverableKeyException e) {
-            throw new CipherToolException("Error retrieving key associated with alias : " + keyAlias, e);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            throw new CipherToolException(CIPHER_INIT_ERROR_MESSAGE, e);
+        } catch (KeyStoreException | UnrecoverableKeyException e) {
+            throw new CipherToolException(GET_KEY_ERROR_MESSAGE + keyAlias, e);
         }
     }
 
@@ -97,8 +100,10 @@ public class SymmetricCipher implements CipherMode {
                 cipher.init(Cipher.ENCRYPT_MODE, this.secretKey);
                 return Utils.doEncryption(cipher, plainText);
             }
-        } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
-            throw new CipherToolException("Error initializing Cipher ", e);
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new CipherToolException(CIPHER_INIT_ERROR_MESSAGE, e);
+        }  catch (InvalidKeyException e) {
+            throw new CipherToolException(INVALID_SECRET_ERROR_MESSAGE, e);
         }
     }
 
@@ -123,9 +128,10 @@ public class SymmetricCipher implements CipherMode {
                 encryptedText = Base64.getDecoder().decode(cipherText.getBytes(StandardCharsets.UTF_8));
             }
             return Utils.doDecryption(cipher, encryptedText);
-        } catch (InvalidKeyException |
-                 InvalidAlgorithmParameterException e) {
-            throw new CipherToolException("Error initializing Cipher ", e);
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new CipherToolException(CIPHER_INIT_ERROR_MESSAGE, e);
+        }  catch (InvalidKeyException e) {
+            throw new CipherToolException(INVALID_SECRET_ERROR_MESSAGE, e);
         }
     }
 

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
@@ -70,6 +70,7 @@ public class Constants {
     public static final String SECTION_SUFFIX = "]";
     public static final String KEY_VALUE_SEPERATOR = "=";
     public static final String AES_GCM_NO_PADDING = "AES/GCM/NoPadding";
+    public static final String RSA = "RSA";
 
     public static final class PrimaryKeyStore {
         public static final String KEY_LOCATION_XPATH = "//Server/Security/KeyStore/Location";

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
@@ -73,6 +73,10 @@ public class Constants {
     public static final String KEY_VALUE_SEPERATOR = "=";
     public static final String AES_GCM_NO_PADDING = "AES/GCM/NoPadding";
     public static final String RSA = "RSA";
+    public static final String CIPHERTEXT = "cipherText";
+    public static final String IV = "iv";
+    public static final String INTERNAL = "Internal";
+    public static final String PRIMARY = "Primary";
 
     public static final class PrimaryKeyStore {
         public static final String KEY_LOCATION_XPATH = "//Server/Security/KeyStore/Location";
@@ -115,5 +119,26 @@ public class Constants {
         public static final String KEYSTORE_KEY_PASSWORD = "keystore.identity.key.password";
         public static final String IDENTITY_KEY_PASSWORD = "identity.key.password";
         public static final String KEYSTORE_KEY_SECRET_PROVIDER = "keystore.identity.key.secretProvider";
+    }
+
+    public enum Error {
+
+        GET_KEY_ERROR_MESSAGE("Error retrieving key associated with alias : %s"),
+        CIPHER_INIT_ERROR_MESSAGE("Error initializing Cipher."),
+        INVALID_SECRET_ERROR_MESSAGE("The provided secret key is invalid."),
+        JSON_VALUE_NOT_FOUND("Value \"%s\" not found in JSON"),
+        TOML_NOT_FOUND("Deployment file %s not found"),
+        PARAMETER_REQUIRED_FOR_ROTATE_MODE("%s parameter is required for key rotate mode mode."),
+        INVALID_JSON("Invalid encrypted text: JSON parsing failed.");
+
+        private final String messageTemplate;
+
+        Error(String messageTemplate) {
+            this.messageTemplate = messageTemplate;
+        }
+
+        public String getMessage(Object... args) {
+            return String.format(this.messageTemplate, args);
+        }
     }
 }

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
@@ -26,6 +26,7 @@ public class Constants {
     public static final String CARBON_HOME = "carbon.home";
     public static final String HOME_FOLDER = "home.folder";
     public static final String TRUE = "true";
+    public static final String SYMMETRIC = "symmetric";
     public static final String REPOSITORY_DIR = "repository";
     public static final String CONF_DIR = "conf";
     public static final String SECURITY_DIR = "security";
@@ -68,6 +69,7 @@ public class Constants {
     public static final String SECTION_PREFIX = "[";
     public static final String SECTION_SUFFIX = "]";
     public static final String KEY_VALUE_SEPERATOR = "=";
+    public static final String AES_GCM_NO_PADDING = "AES/GCM/NoPadding";
 
     public static final class PrimaryKeyStore {
         public static final String KEY_LOCATION_XPATH = "//Server/Security/KeyStore/Location";
@@ -96,6 +98,8 @@ public class Constants {
         public static final String CARBON_SECRET_PROVIDER = "carbon.secretProvider";
         public static final String SECRET_FILE_PROVIDER = "secretRepositories.file.provider";
         public static final String SECRET_FILE_ALGORITHM= "secretRepositories.file.algorithm";
+        public static final String SECRET_FILE_ENCRYPTION_MODE=
+                "secretRepositories.file.encryptionMode";
         public static final String SECRET_FILE_BASE_PROVIDER_CLASS =
                 "org.wso2.securevault.secret.repository.FileBaseSecretRepositoryProvider";
         public static final String SECRET_FILE_LOCATION = "secretRepositories.file.location";

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
@@ -23,10 +23,12 @@ public class Constants {
     public static final String KEYSTORE_PASSWORD = "keystore.password";
     public static final String CONFIGURE = "configure";
     public static final String CHANGE = "change";
+    public static final String ROTATE = "rotate";
     public static final String CARBON_HOME = "carbon.home";
     public static final String HOME_FOLDER = "home.folder";
     public static final String TRUE = "true";
     public static final String SYMMETRIC = "symmetric";
+    public static final String OLD_KEY_ALIAS = "old.alias";
     public static final String REPOSITORY_DIR = "repository";
     public static final String CONF_DIR = "conf";
     public static final String SECURITY_DIR = "security";

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/KeyStoreUtil.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/KeyStoreUtil.java
@@ -76,7 +76,7 @@ public class KeyStoreUtil {
         return cipher;
     }
 
-    private static KeyStore getKeyStore(String location, String storePassword, String storeType) {
+    public static KeyStore getKeyStore(String location, String storePassword, String storeType) {
         BufferedInputStream bufferedInputStream = null;
         try {
             bufferedInputStream = new BufferedInputStream(new FileInputStream(location));

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/KeyStoreUtil.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/KeyStoreUtil.java
@@ -40,7 +40,7 @@ public class KeyStoreUtil {
     public static String getKeystorePassword() {
 
         String password;
-        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? "Primary" : "Internal");
+        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? Constants.PRIMARY : Constants.INTERNAL);
         if (StringUtils.isNotEmpty(System.getProperty(Constants.KEYSTORE_PASSWORD))) {
             password = System.getProperty(Constants.KEYSTORE_PASSWORD);
         } else {
@@ -60,7 +60,7 @@ public class KeyStoreUtil {
      */
     public static KeyStore getKeyStore() {
 
-        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? "Primary" : "Internal");
+        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? Constants.PRIMARY : Constants.INTERNAL);
         String keyStoreFile = System.getProperty(Constants.KEY_LOCATION_PROPERTY);
         String keyType = System.getProperty(Constants.KEY_TYPE_PROPERTY);
         String password = getKeystorePassword();
@@ -74,7 +74,7 @@ public class KeyStoreUtil {
      */
     public static Cipher initializeCipher() {
         Cipher cipher;
-        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? "Primary" : "Internal");
+        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? Constants.PRIMARY : Constants.INTERNAL);
         String keyStoreFile = System.getProperty(Constants.KEY_LOCATION_PROPERTY);
         String keyType = System.getProperty(Constants.KEY_TYPE_PROPERTY);
         String keyAlias = System.getProperty(Constants.KEY_ALIAS_PROPERTY);

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/KeyStoreUtil.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/KeyStoreUtil.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.ciphertool.utils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.wso2.ciphertool.exception.CipherToolException;
 
 import javax.crypto.Cipher;
@@ -30,6 +31,42 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 
 public class KeyStoreUtil {
+
+    /**
+     * Retrieves the password for the keystore.
+     *
+     * @return The keystore password.
+     */
+    public static String getKeystorePassword() {
+
+        String password;
+        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? "Primary" : "Internal");
+        if (StringUtils.isNotEmpty(System.getProperty(Constants.KEYSTORE_PASSWORD))) {
+            password = System.getProperty(Constants.KEYSTORE_PASSWORD);
+        } else {
+            password = Utils.getValueFromConsole("Please Enter " + keyStoreName + " KeyStore Password of Carbon Server : ", true);
+            System.setProperty(Constants.KEYSTORE_PASSWORD, password);
+        }
+        if (password == null) {
+            throw new CipherToolException("KeyStore password can not be null");
+        }
+        return password;
+    }
+
+    /**
+     * Retrieves the keystore for the Carbon Server.
+     *
+     * @return The keystore.
+     */
+    public static KeyStore getKeyStore() {
+
+        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? "Primary" : "Internal");
+        String keyStoreFile = System.getProperty(Constants.KEY_LOCATION_PROPERTY);
+        String keyType = System.getProperty(Constants.KEY_TYPE_PROPERTY);
+        String password = getKeystorePassword();
+        System.out.println("\n" + keyStoreName + " KeyStore of Carbon Server is initialized Successfully\n");
+        return getKeyStore(keyStoreFile, password, keyType);
+    }
 
     /**
      * Initializes the Cipher

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -520,6 +520,25 @@ public class Utils {
     }
 
     /**
+     * Decrypt the cipher text password.
+     *
+     * @param cipher        Initialized cipher object.
+     * @param cipherTextPwd Encrypted password.
+     * @return Plain text password.
+     */
+    public static String doDecryption(Cipher cipher, byte[] cipherTextPwd) {
+        String encodedValue;
+        try {
+            byte[] encryptedPassword = cipher.doFinal(cipherTextPwd);
+            encodedValue = new String(encryptedPassword);
+        } catch (BadPaddingException | IllegalBlockSizeException e) {
+            throw new CipherToolException("Error decrypting password ", e);
+        }
+        System.out.println("\nDecryption is done Successfully\n");
+        return encodedValue;
+    }
+
+    /**
      * Read toml file and return list of secrets
      *
      * @param configFilePath    file path to deployment toml
@@ -606,6 +625,20 @@ public class Utils {
         String unEncryptedValue = StringUtils.substring(value, value.indexOf(Constants.SECTION_PREFIX) + 1,
                 value.lastIndexOf(Constants.SECTION_SUFFIX));
         return StringUtils.isNotEmpty(unEncryptedValue) ? unEncryptedValue : null;
+    }
+
+    /**
+     * Read encrypted value from [secrets] section in deployment toml file.
+     *
+     * @param value Key to read.
+     * @return      Unencrypted value.
+     */
+    public static String getEncryptedValue(String value) {
+
+        if (value.contains(Constants.SECTION_PREFIX) && value.contains(Constants.SECTION_SUFFIX)) {
+            return null;
+        }
+        return StringUtils.isNotEmpty(value) ? value : null;
     }
 
     /**

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -328,7 +328,7 @@ public class Utils {
 
                 keyStoreFile = resolveKeyStorePath(keyStoreFile, homeFolder, defaultConfigMap);
                 System.setProperty(Constants.KEY_LOCATION_PROPERTY, keyStoreFile);
-                String keyStoreName = ((Utils.isPrimaryKeyStore()) ? "Primary" : "Internal");
+                String keyStoreName = ((Utils.isPrimaryKeyStore()) ? Constants.PRIMARY : Constants.INTERNAL);
 
                 if (Constants.TRUE.equals((System.getProperty(Constants.SYMMETRIC)))) {
                     System.out.println("\nSymmetric encryption using " + keyStoreName + " KeyStore.");
@@ -628,10 +628,10 @@ public class Utils {
     }
 
     /**
-     * Read encrypted value from [secrets] section in deployment toml file.
+     * Returns value from [secrets] section in deployment toml file, if encrypted.
      *
-     * @param value Key to read.
-     * @return      Unencrypted value.
+     * @param value The input string to be checked
+     * @return The input string if it does not contain '[' or ']' otherwise, returns null.
      */
     public static String getEncryptedValue(String value) {
 

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <orbit.version.axiom>1.2.11.wso2v6</orbit.version.axiom>
         <maven.dependency.plugin.version>2.8</maven.dependency.plugin.version>
         <axiom.version>1.2.11.wso2v11</axiom.version>
-        <gson.version>2.3.1</gson.version>
+        <gson.version>2.9.0</gson.version>
         <bcprov-jdk15on.version>1.52</bcprov-jdk15on.version>
         <commons-cli.version>1.4</commons-cli.version>
         <commons-io.version>2.6</commons-io.version>


### PR DESCRIPTION
## Purpose
Support AES/GCM/NoPadding and AES/ECB/PKCS5Padding symmetric encryption methods.

Use the following command to configure symmetric encryption
```
sh ciphertool.sh -Dconfigure -Dsymmetric
```

Added a key rotate mode to rotate secret key from asymmetric to symmetric
```
sh ciphertool.sh -Drotate -Dsymmetric -Dold.alias=wso2carbon 
```
This rotate mode can also be use to rotate between symmetric to symmetric and symmetric to asymmetric

## Related issue
- https://github.com/wso2/product-is/issues/20610