### PR TITLE
Update CARBON_CLASSPATH

### DIFF
--- a/features/org.wso2.ciphertool.feature/resources/bin/ciphertool.bat
+++ b/features/org.wso2.ciphertool.feature/resources/bin/ciphertool.bat
@@ -75,8 +75,8 @@ rem loop through the libs and add them to the class path
 cd "%CARBON_HOME%"
 call ant -buildfile "%CARBON_HOME%\bin\build.xml" -q
 set CARBON_CLASSPATH=.\conf
-FOR %%c in ("%CARBON_HOME%\lib\*.jar") DO set CARBON_CLASSPATH=!CARBON_CLASSPATH!;".\lib\%%~nc%%~xc"
-FOR %%C in ("%CARBON_HOME%\repository\lib\*.jar") DO set CARBON_CLASSPATH=!CARBON_CLASSPATH!;".\repository\lib\%%~nC%%~xC"
+set CARBON_CLASSPATH=%CARBON_CLASSPATH%;".\lib\*"
+set CARBON_CLASSPATH=%CARBON_CLASSPATH%;".\repository\components\plugins\*"
 
 rem ----- Execute The Requested Command ---------------------------------------
 echo Using CARBON_HOME:   %CARBON_HOME%

--- a/features/org.wso2.ciphertool.feature/resources/bin/ciphertool.sh
+++ b/features/org.wso2.ciphertool.feature/resources/bin/ciphertool.sh
@@ -102,17 +102,8 @@ if $mingw ; then
   # TODO classpath?
 fi
 
-# update classpath
-CARBON_CLASSPATH=""
-for f in "$CARBON_HOME"/lib/*.jar
-do
-  CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
-done
-for h in "$CARBON_HOME"/repository/components/plugins/*.jar
-do
-  CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
-done
-CARBON_CLASSPATH=$CARBON_CLASSPATH:$CLASSPATH
+#Update classpath using folder-based approach
+CARBON_CLASSPATH="$CARBON_HOME/lib/*:$CARBON_HOME/repository/components/plugins/*:$CLASSPATH"
 
 # For Cygwin, switch paths to Windows format before running java
 if $cygwin; then


### PR DESCRIPTION
## Purpose
- Previously we had appended each jar in `repository/components/plugins` and `lib` folders to the CARBON_CLASSPATH varialble. This led to a `Argument list too long` error while executing the ciphertool.
- This PR updates `CARBON_CLASSPATH` using folder based approach.

[1]. https://github.com/wso2/api-manager/issues/3752

## Approach
- Instead of attachinh each jar file in the folders, we now append only the root folder to the `CARBON_CLASSPATH` variable. [2]

[2]. https://docs.oracle.com/javase/8/docs/technotes/tools/windows/classpath.html#A1100762 