### PR TITLE
Fix NPE in CipherTool when deployment.toml has configurations after s…

### DIFF
--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
@@ -384,7 +384,10 @@ public class CipherTool {
                             if (stringTokenizer.hasMoreTokens()) {
                                 String key = stringTokenizer.nextToken();
                                 String value = encryptedKeyMap.get(key.trim());
-                                line = key.concat("= \"").concat(value).concat("\"");
+                                // Fix: Check if value exists before replacing
+                                if (value != null) {
+                                    line = key.concat("= \"").concat(value).concat("\"");
+                                }
                             }
                         }
                     } else {


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/api-manager/issues/4561

This PR fixes a critical `NullPointerException` in the CipherTool that occurs when the `deployment.toml` file contains configuration sections defined *after* the `[secrets]` section.

## Goals
- Fix the crash in `ciphertool` when users add custom configurations or new sections at the end of `deployment.toml`.
- Ensure the tool gracefully handles keys that are not present in the `encryptedKeyMap` instead of throwing a runtime exception.

## Approach
The crash was caused by the tool attempting to encrypt keys found in sections following the `[secrets]` block. When the tool encountered a key from a subsequent section (e.g., `[test_section]`), it tried to look up its value in the `encryptedKeyMap`. Since the key was not a secret, the map returned `null`. The code then attempted to concatenate this `null` value (`.concat(value)`), resulting in a `NullPointerException`.

I implemented a null check for the retrieved `value`. If the value is null, the code now skips the line modification, preserving the configuration as-is without crashing.

## User stories
As a System Administrator or DevOps Engineer, I want to be able to add custom configuration sections to the bottom of my `deployment.toml` file without causing the `ciphertool` script to crash, so that I can safely manage my environment configurations and secrets.

## Release note
Fixed a `NullPointerException` in the CipherTool utility that occurred when `deployment.toml` contained configuration sections placed after the `[secrets]` block.

## Documentation
N/A - This is a bug fix for an internal utility and does not require documentation updates.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
   > N/A - Manual verification was performed.
 - Integration tests
   > Verified manually by:
   > 1. Modifying `deployment.toml` in WSO2 API Manager 4.6.0 to include a `[test_section]` after `[secrets]`.
   > 2. Running `./ciphertool.bat -Dconfigure -Dpassword=wso2carbon`.
   > 3. Confirming the tool completes successfully and secrets are encrypted.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
 - Ran FindSecurityBugs plugin and verified report? **yes**
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes**

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
- **JDK:** Amazon Corretto 11.0.29
- **OS:** Windows 11
- **Product:** WSO2 API Manager 4.6.0
 
## Learning
Identified that the tokenizer logic in `CipherTool.java` did not account for scenarios where keys might be parsed from non-secret sections if the section parsing logic allows fall-through, leading to null values in the encryption map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced deployment configuration encryption to prevent invalid null values from being inserted during the encryption process, improving overall reliability of encrypted configuration handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->