### PR TITLE
Add symmetric encryption for CipherTool

### DIFF
--- a/components/ciphertool/pom.xml
+++ b/components/ciphertool/pom.xml
@@ -46,6 +46,10 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/CipherTool.java
@@ -20,6 +20,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.wso2.ciphertool.cipher.AsymmetricCipher;
+import org.wso2.ciphertool.cipher.CipherFactory;
+import org.wso2.ciphertool.cipher.CipherMode;
+import org.wso2.ciphertool.cipher.SymmetricCipher;
 import org.wso2.ciphertool.exception.CipherToolException;
 import org.wso2.ciphertool.utils.Constants;
 import org.wso2.ciphertool.utils.KeyStoreUtil;
@@ -27,6 +31,7 @@ import org.wso2.ciphertool.utils.Utils;
 import org.xml.sax.SAXException;
 
 import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
@@ -35,13 +40,31 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import javax.xml.xpath.*;
-import java.io.*;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.*;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringTokenizer;
 
 import static org.wso2.ciphertool.utils.Utils.getSecuredDocumentBuilder;
 
@@ -54,9 +77,9 @@ public class CipherTool {
     public static void main(String[] args) {
 
         initialize(args);
-        Cipher cipher = KeyStoreUtil.initializeCipher();
-        if (System.getProperty(Constants.CONFIGURE) != null &&
-            System.getProperty(Constants.CONFIGURE).equals(Constants.TRUE)) {
+        KeyStore keyStore = KeyStoreUtil.getKeyStore();
+        CipherMode cipherMode = CipherFactory.createCipher(keyStore);
+        if (Constants.TRUE.equals(System.getProperty(Constants.CONFIGURE))) {
             File deploymentTomlFile = new File(Utils.getDeploymentFilePath());
             if (deploymentTomlFile.exists()) {
                 Map<String, String> secretMap = Utils.getSecreteFromConfiguration(Utils.getDeploymentFilePath());
@@ -64,7 +87,7 @@ public class CipherTool {
                     String key = entry.getKey();
                     String value = Utils.getUnEncryptedValue(entry.getValue());
                     if (StringUtils.isNotEmpty(value)) {
-                        String encryptedValue = Utils.doEncryption(cipher, value);
+                        String encryptedValue = cipherMode.doEncryption(value);
                         secretMap.replace(key, encryptedValue);
                     }
                 }
@@ -72,14 +95,40 @@ public class CipherTool {
             } else {
                 loadXpathValuesAndPasswordDetails();
                 secureVaultConfigTokens();
-                encryptCipherTextFile(cipher);
+                encryptCipherTextFile(cipherMode);
             }
             Utils.writeToSecureConfPropertyFile();
-        } else if (System.getProperty(Constants.CHANGE) != null &&
-                   System.getProperty(Constants.CHANGE).equals(Constants.TRUE)) {
-            changePassword(cipher);
+        } else if (Constants.TRUE.equals(System.getProperty(Constants.ROTATE))) {
+            String oldAlias  = System.getProperty(Constants.OLD_KEY_ALIAS);
+            if (StringUtils.isBlank(oldAlias)) {
+                throw new CipherToolException(
+                        Constants.Error.PARAMETER_REQUIRED_FOR_ROTATE_MODE.getMessage(Constants.OLD_KEY_ALIAS));
+            }
+            CipherMode oldCipherMode = isSymmetricKey(oldAlias, keyStore)
+                    ? new SymmetricCipher(keyStore, oldAlias) : new AsymmetricCipher(keyStore, oldAlias);
+            File deploymentTomlFile = new File(Utils.getDeploymentFilePath());
+            if (deploymentTomlFile.exists()) {
+                Map<String, String> secretMap = Utils.getSecreteFromConfiguration(Utils.getDeploymentFilePath());
+                for (Map.Entry<String, String> entry : secretMap.entrySet()) {
+                    String key = entry.getKey();
+                    String oldEncryptedValue = Utils.getEncryptedValue(entry.getValue());
+                    if (StringUtils.isNotEmpty(oldEncryptedValue)) {
+                        String value = oldCipherMode.doDecryption(oldEncryptedValue);
+                        if (StringUtils.isNotEmpty(value)) {
+                            String encryptedValue = cipherMode.doEncryption(value);
+                            secretMap.replace(key, encryptedValue);
+                        }
+                    }
+                }
+                updateDeploymentConfigurationWithEncryptedKeys(secretMap);
+            } else {
+                throw new CipherToolException(Constants.Error.TOML_NOT_FOUND.getMessage(deploymentTomlFile));
+            }
+            Utils.writeToSecureConfPropertyFile();
+        } else if (Constants.TRUE.equals(System.getProperty(Constants.CHANGE))) {
+            changePassword(cipherMode);
         } else {
-            encryptedValue(cipher);
+            encryptedValue(cipherMode);
         }
     }
 
@@ -107,10 +156,19 @@ public class CipherTool {
                 } else if ((Constants.CHANGE).equalsIgnoreCase(propertyName)) {
                     System.setProperty(property, Constants.TRUE);
                 } else if ((Constants.CIPHER_TRANSFORMATION_SYSTEM_PROPERTY).equalsIgnoreCase(propertyName)) {
+                } else if ((Constants.SYMMETRIC).equals(propertyName)) {
+                    System.setProperty(property, Constants.TRUE);
+                } else if (Constants.ROTATE.equals(propertyName)) {
+                    System.setProperty(property, Constants.TRUE);
+                } else if (Constants.OLD_KEY_ALIAS.equals(propertyName)) {
+                    if (!StringUtils.isBlank(value)) {
+                        System.setProperty(Constants.OLD_KEY_ALIAS, value);
+                    }
+                } else if ((Constants.CIPHER_TRANSFORMATION_SYSTEM_PROPERTY).equals(propertyName)) {
                     if (!StringUtils.isBlank(value)) {
                         System.setProperty(Constants.CIPHER_TRANSFORMATION_SYSTEM_PROPERTY, value);
                     } else {
-                        System.out.println("Invalid transformation algorithm provided. The default transformation algorithm (RSA) will be used");
+                        System.out.println("Invalid transformation algorithm provided. The default transformation algorithm will be used");
                     }
                 } else if (propertyName.equalsIgnoreCase(Constants.JCEProviders.SECURITY_JCE_PROVIDER)) {
                     if (StringUtils.isNotEmpty(value) &&
@@ -154,6 +212,11 @@ public class CipherTool {
 
         System.out.println("\t-Dchange\t\t This option would allow user to change the specific password which has " +
                            "been secured\n");
+        System.out.println("\t-Drotate\t\t This option is used to rotate the existing encrypted values to a new secret " +
+                "alias. Requires providing the old alias.\n");
+        System.out.println("\t-Dsymmetric\t\t This option allows the user to use symmetric encryption for creating " +
+                "encrypted values. It can be used with -Dconfigure, -Dchange, or -Drotate.\n");
+        System.out.println("\t-Dold.alias=<Old secret alias>\t This specifies the old alias used in rotate mode.");
         System.out.println("\t-Dpassword=<password>\t This option would allow user to provide the password as a " +
                            "command line argument. NOTE: Providing the password in command line arguments list is " +
                            "not recommended.\n");
@@ -162,16 +225,16 @@ public class CipherTool {
     }
 
     /**
-     * encrypt text retrieved from Console
+     * Encrypt text retrieved from Console.
      *
      * @param cipher cipher
      */
-    private static void encryptedValue(Cipher cipher) {
+    private static void encryptedValue(CipherMode cipherMode) {
         String firstPassword = Utils.getValueFromConsole("Enter Plain Text Value : ", true);
         String secondPassword = Utils.getValueFromConsole("Please Enter Value Again : ", true);
 
         if (!firstPassword.isEmpty() && firstPassword.equals(secondPassword)) {
-            String encryptedText = Utils.doEncryption(cipher, firstPassword);
+            String encryptedText = cipherMode.doEncryption(firstPassword);
             System.out.println("\nEncrypted value is : \n" + encryptedText + "\n");
         } else {
             throw new CipherToolException("Error : Password does not match");
@@ -299,19 +362,19 @@ public class CipherTool {
      * Encrypt plain text password defined in cipher-text.properties file. If not read password from command-line and
      * save to cipher-text.properties
      *
-     * @param cipher cipher
+     * @param cipherMode Cipher mode (asymmetric or symmetric).
      */
-    private static void encryptCipherTextFile(Cipher cipher) {
+    private static void encryptCipherTextFile(CipherMode cipherMode) {
         Properties properties = new Properties();
         for (Map.Entry<String, String> entry : aliasPasswordMap.entrySet()) {
             String value = entry.getValue();
             if (value != null && !value.equals("")) {
                 if (value.contains("[") && value.indexOf("]") > 0) {
                     value = value.substring(value.indexOf("[") + 1, value.indexOf("]"));
-                    value = Utils.doEncryption(cipher, value);
+                    value = cipherMode.doEncryption(value);
                 }
             } else {
-                value = getPasswordFromConsole(entry.getKey(), cipher);
+                value = getPasswordFromConsole(entry.getKey(), cipherMode);
             }
             properties.setProperty(entry.getKey(), value);
         }
@@ -322,14 +385,14 @@ public class CipherTool {
     /**
      * returns the encrypted value entered via the Console for the given Secret Alias
      * @param key key
-     * @param cipher cipher
+     * @param cipherMode Cipher mode (asymmetric or symmetric).
      * @return encrypted value
      */
-    private static String getPasswordFromConsole(String key, Cipher cipher) {
+    private static String getPasswordFromConsole(String key, CipherMode cipherMode) {
         String firstPassword = Utils.getValueFromConsole("Enter Password of Secret Alias - '" + key + "' : ", true);
         String secondPassword = Utils.getValueFromConsole("Please Enter Password Again : ", true);
         if (!firstPassword.isEmpty() && firstPassword.equals(secondPassword)) {
-            String encryptedValue = Utils.doEncryption(cipher, firstPassword);
+            String encryptedValue = cipherMode.doEncryption(firstPassword);
             aliasPasswordMap.put(key, encryptedValue);
             return encryptedValue;
         } else {
@@ -338,9 +401,11 @@ public class CipherTool {
     }
 
     /**
-     * use to change an specific password.
+     * Use to change a specific password.
+     *
+     * @param cipherMode Cipher mode (asymmetric or symmetric).
      */
-    private static void changePassword(Cipher cipher) {
+    private static void changePassword(CipherMode cipherMode) {
         File deploymentTomlFile = new File(Utils.getDeploymentFilePath());
         List<String> keyValueList = new ArrayList<String>();
         if (deploymentTomlFile.exists()) {
@@ -362,7 +427,7 @@ public class CipherTool {
                         + "[Press Enter to Skip] : ", false)).isEmpty()) {
             if (!value.trim().equals("")) {
                 String selectedPasswordAlias = keyValueList.get(Integer.parseInt(value.trim()) - 1);
-                String newEncryptedValue = getPasswordFromConsole(selectedPasswordAlias, cipher);
+                String newEncryptedValue = getPasswordFromConsole(selectedPasswordAlias, cipherMode);
                 aliasPasswordMap.put(selectedPasswordAlias, newEncryptedValue);
                 isModified = true;
             }
@@ -416,5 +481,28 @@ public class CipherTool {
      */
     public static String getProviderName() {
         return providerName;
+    }
+
+    /**
+     * Checks if the key associated with the given alias in the provided keystore is a symmetric key.
+     *
+     * @param keyAlias the alias of the key to be checked.
+     * @param keystore the keystore containing the key.
+     * @return true if the key is a symmetric key, false otherwise.
+     * @throws CipherToolException if there is an error initializing the cipher or retrieving the key
+     */
+    private static boolean isSymmetricKey(String keyAlias, KeyStore keystore) {
+        try {
+            Key key = keystore.getKey(keyAlias, KeyStoreUtil.getKeystorePassword().toCharArray());
+            // Check if the key is symmetric or not.
+            if (key instanceof SecretKey) {
+                return true;
+            }
+        } catch (KeyStoreException | NoSuchAlgorithmException e) {
+            throw new CipherToolException("Error initializing Cipher ", e);
+        } catch (UnrecoverableKeyException e) {
+            throw new CipherToolException("Error retrieving key associated with alias : " + keyAlias, e);
+        }
+        return false;
     }
 }

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/AsymmetricCipher.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/AsymmetricCipher.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.ciphertool.cipher;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.ciphertool.exception.CipherToolException;
+import org.wso2.ciphertool.utils.Constants;
+import org.wso2.ciphertool.utils.KeyStoreUtil;
+import org.wso2.ciphertool.utils.Utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+
+/**
+ * Provides methods for encryption and decryption using asymmetric key algorithms.
+ */
+public class AsymmetricCipher implements CipherMode {
+
+    private final String keyAlias;
+    private final KeyStore keyStore;
+    private final Cipher cipher;
+
+    public AsymmetricCipher(KeyStore keyStore, String keyAlias) {
+
+        this.keyStore = keyStore;
+        this.keyAlias = keyAlias;
+        String cipherTransformation = System.getProperty(Constants.CIPHER_TRANSFORMATION_SYSTEM_PROPERTY);
+        String algorithm = StringUtils.isNotBlank(cipherTransformation)
+                ? cipherTransformation : Constants.RSA;
+        try {
+            this.cipher = Cipher.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            throw new CipherToolException(Constants.Error.CIPHER_INIT_ERROR_MESSAGE.getMessage(), e);
+        }
+    }
+
+    public AsymmetricCipher(KeyStore keyStore) {
+
+        this(keyStore, System.getProperty(Constants.KEY_ALIAS_PROPERTY));
+    }
+
+    /**
+     * Encrypt plain text using asymmetric encryption.
+     *
+     * @param plainText Plain text password.
+     * @return Encrypted password.
+     */
+    @Override
+    public String doEncryption(String plainText) {
+
+        try {
+            Certificate certs = this.keyStore.getCertificate(this.keyAlias);
+            cipher.init(Cipher.ENCRYPT_MODE, certs);
+        } catch (KeyStoreException e) {
+            throw new CipherToolException(Constants.Error.GET_KEY_ERROR_MESSAGE.getMessage(this.keyAlias), e);
+        } catch (InvalidKeyException e) {
+            throw new CipherToolException("The provided public cert is invalid.", e);
+        }
+        return Utils.doEncryption(cipher, plainText);
+    }
+
+    /**
+     * Decrypt encrypted text using encryption.
+     *
+     * @param cipherText Encrypted password.
+     * @return Plain text password.
+     */
+    @Override
+    public String doDecryption(String cipherText) {
+
+        try {
+            Key privateKey = this.keyStore.getKey(this.keyAlias, KeyStoreUtil.getKeystorePassword().toCharArray());
+            cipher.init(Cipher.DECRYPT_MODE, privateKey);
+        }  catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new CipherToolException("The provided private key is invalid.", e);
+        } catch (KeyStoreException | UnrecoverableKeyException e) {
+            throw new CipherToolException(Constants.Error.GET_KEY_ERROR_MESSAGE.getMessage(this.keyAlias), e);
+        }
+        return Utils.doDecryption(cipher, Base64.getDecoder().decode(cipherText.getBytes(StandardCharsets.UTF_8)));
+    }
+
+}

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherFactory.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.ciphertool.cipher;
+
+import org.wso2.ciphertool.utils.Constants;
+
+import java.security.KeyStore;
+
+/**
+ * The CipherFactory class provides a static method to create either a SymmetricCipher or AsymmetricCipher
+ * based on a system property.
+ */
+public class CipherFactory {
+
+    private CipherFactory() {
+
+    }
+
+    /**
+     * Creates an instance of CipherMode based on the {@code Constants.SYMMETRIC} system property.
+     *
+     * @return An instance of {@code CipherMode}, either {@code SymmetricCipher} or {@code AsymmetricCipher}.
+     */
+    public static CipherMode createCipher(KeyStore keyStore) {
+
+        if (Constants.TRUE.equals(System.getProperty(Constants.SYMMETRIC))) {
+            return new SymmetricCipher(keyStore);
+        } else {
+            return new AsymmetricCipher(keyStore);
+        }
+    }
+
+}

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherMode.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/CipherMode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.ciphertool.cipher;
+
+/**
+ * The interface for providing methods for encrypting and decrypting text.
+ */
+public interface CipherMode {
+
+    /**
+     * Encrypt plain text using encryption.
+     *
+     * @param plainText Plain text password.
+     * @return Encrypted password.
+     */
+    String doEncryption(String plainText);
+
+    /**
+     * Decrypt cipher text into plain text using decryption.
+     *
+     * @param cipherText Cipher text.
+     * @return Decrypted plain text.
+     */
+    String doDecryption(String cipherText);
+}

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/cipher/SymmetricCipher.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.ciphertool.cipher;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+import org.apache.commons.lang.StringUtils;
+import org.wso2.ciphertool.exception.CipherToolException;
+import org.wso2.ciphertool.utils.Constants;
+import org.wso2.ciphertool.utils.KeyStoreUtil;
+import org.wso2.ciphertool.utils.Utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.UnrecoverableKeyException;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.GCMParameterSpec;
+
+/**
+ * Provides methods for encryption and decryption using symmetric key algorithms.
+ */
+public class SymmetricCipher implements CipherMode {
+
+    private static final int GCM_IV_LENGTH = 128;
+    private static final int GCM_TAG_LENGTH = 128;
+    private final Key secretKey;
+    private final Cipher cipher;
+    private final String algorithm;
+
+    public SymmetricCipher(KeyStore keyStore, String keyAlias) {
+
+        String cipherTransformation = System.getProperty(Constants.CIPHER_TRANSFORMATION_SYSTEM_PROPERTY);
+        this.algorithm = StringUtils.isNotBlank(cipherTransformation)
+                ? cipherTransformation : Constants.AES_GCM_NO_PADDING;
+        String password = KeyStoreUtil.getKeystorePassword();
+        try {
+            this.secretKey = keyStore.getKey(keyAlias, password.toCharArray());
+            if (this.secretKey == null) {
+                throw new KeyStoreException(Constants.Error.GET_KEY_ERROR_MESSAGE.getMessage(keyAlias));
+            }
+            this.cipher = Cipher.getInstance(this.algorithm);
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            throw new CipherToolException(Constants.Error.CIPHER_INIT_ERROR_MESSAGE.getMessage(), e);
+        } catch (KeyStoreException | UnrecoverableKeyException e) {
+            throw new CipherToolException(Constants.Error.GET_KEY_ERROR_MESSAGE.getMessage(keyAlias), e);
+        }
+    }
+
+    public SymmetricCipher(KeyStore keyStore) {
+
+        this(keyStore, System.getProperty(Constants.KEY_ALIAS_PROPERTY));
+    }
+
+    /**
+     * Encrypt plain text using encryption.
+     *
+     * @param plainText Plain text password.
+     * @return Encrypted password.
+     */
+    @Override
+    public String doEncryption(String plainText) {
+
+        try {
+            if (Constants.AES_GCM_NO_PADDING.equals(this.algorithm)) {
+                byte[] iv = getInitializationVector();
+                cipher.init(Cipher.ENCRYPT_MODE, this.secretKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+                String cipherText = Utils.doEncryption(cipher, plainText);
+                return createSelfContainedCiphertextWithGCMMode(cipherText, iv);
+            } else {
+                cipher.init(Cipher.ENCRYPT_MODE, this.secretKey);
+                return Utils.doEncryption(cipher, plainText);
+            }
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new CipherToolException(Constants.Error.CIPHER_INIT_ERROR_MESSAGE.getMessage(), e);
+        }  catch (InvalidKeyException e) {
+            throw new CipherToolException(Constants.Error.INVALID_SECRET_ERROR_MESSAGE.getMessage(), e);
+        }
+    }
+
+    /**
+     * Decrypt encrypted text using encryption.
+     *
+     * @param cipherText Encrypted password.
+     * @return Plain text password.
+     */
+    @Override
+    public String doDecryption(String cipherText) {
+
+        try {
+            byte[] encryptedText;
+            if (Constants.AES_GCM_NO_PADDING.equals(this.algorithm)) {
+                JsonObject jsonObject = getJsonObject(cipherText);
+                encryptedText = getValueFromJson(jsonObject, Constants.CIPHERTEXT);
+                byte[] iv = getValueFromJson(jsonObject, Constants.IV);
+                cipher.init(Cipher.DECRYPT_MODE, this.secretKey, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+            } else {
+                cipher.init(Cipher.DECRYPT_MODE, this.secretKey);
+                encryptedText = Base64.getDecoder().decode(cipherText.getBytes(StandardCharsets.UTF_8));
+            }
+            return Utils.doDecryption(cipher, encryptedText);
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new CipherToolException(Constants.Error.CIPHER_INIT_ERROR_MESSAGE.getMessage(), e);
+        }  catch (InvalidKeyException e) {
+            throw new CipherToolException(Constants.Error.INVALID_SECRET_ERROR_MESSAGE.getMessage(), e);
+        }
+    }
+
+    /**
+     * Decodes the given Base64 encoded string into a JsonObject.
+     *
+     * @param encodedCiphertext Base64 encoded string representing the JSON object.
+     * @return                  The parsed JSON object.
+     * @throws CipherToolException if the provided string is not a valid JSON
+     */
+    private JsonObject getJsonObject(String encodedCiphertext) {
+
+        try {
+            String jsonString = new String(Base64.getDecoder().decode(encodedCiphertext));
+            return JsonParser.parseString(jsonString).getAsJsonObject();
+        } catch (JsonSyntaxException e) {
+            throw new CipherToolException(Constants.Error.INVALID_JSON.getMessage());
+        }
+    }
+
+    /**
+     * Retrieves the value associated with the specified key from the given JsonObject and decodes it from Base64.
+     *
+     * @param jsonObject    JSON object containing the key-value pair.
+     * @param key           Key for the value to be retrieved.
+     * @return The decoded value
+     * @throws CipherToolException if the key is not found in the JsonObject
+     */
+    private byte[] getValueFromJson(JsonObject jsonObject, String key) {
+
+        JsonElement jsonElement = jsonObject.get(key);
+        if (jsonElement == null) {
+            throw new CipherToolException(Constants.Error.JSON_VALUE_NOT_FOUND.getMessage(key));
+        }
+        return Base64.getDecoder().decode(jsonElement.getAsString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Generates a new initialization vector (IV) for GCM encryption.
+     *
+     * @return the generated IV as a byte array
+     */
+    private byte[] getInitializationVector() {
+
+        byte[] iv = new byte[GCM_IV_LENGTH];
+        SecureRandom secureRandom = new SecureRandom();
+        secureRandom.nextBytes(iv);
+        return iv;
+    }
+
+
+    /**
+     * Creates a self-contained ciphertext with GCM mode.
+     *
+     * @param ciphertext    Original ciphertext to be included in the JSON object.
+     * @param iv            Initialization vector.
+     * @return Base64 encoded JSON object containing the ciphertext and IV.
+     */
+    private String createSelfContainedCiphertextWithGCMMode(String ciphertext, byte[] iv) {
+
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty(Constants.CIPHERTEXT, ciphertext);
+        jsonObject.addProperty(Constants.IV, Base64.getEncoder().encodeToString(iv));
+        return Base64.getEncoder().encodeToString(new Gson().toJson(jsonObject).getBytes());
+    }
+}

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Constants.java
@@ -23,9 +23,12 @@ public class Constants {
     public static final String KEYSTORE_PASSWORD = "keystore.password";
     public static final String CONFIGURE = "configure";
     public static final String CHANGE = "change";
+    public static final String ROTATE = "rotate";
     public static final String CARBON_HOME = "carbon.home";
     public static final String HOME_FOLDER = "home.folder";
     public static final String TRUE = "true";
+    public static final String SYMMETRIC = "symmetric";
+    public static final String OLD_KEY_ALIAS = "old.alias";
     public static final String REPOSITORY_DIR = "repository";
     public static final String CONF_DIR = "conf";
     public static final String SECURITY_DIR = "security";
@@ -56,9 +59,15 @@ public class Constants {
     public static final String KEY_VALUE_SEPERATOR = "=";
     // This property will be set to true when external applications need to override the default values
     public static final String SET_EXTERNAL_SYSTEM_PROPERTY = "external.system.properties";
+    public static final String AES_GCM_NO_PADDING = "AES/GCM/NoPadding";
+    public static final String RSA = "RSA";
+    public static final String CIPHERTEXT = "cipherText";
+    public static final String IV = "iv";
+    public static final String INTERNAL = "Internal";
+    public static final String PRIMARY = "Primary";
 
-    public static final String SYS_PROPERTY_PLACEHOLDER_PREFIX = "$sys{"; 
-    public static final String ENV_VAR_PLACEHOLDER_PREFIX = "$env{"; 
+    public static final String SYS_PROPERTY_PLACEHOLDER_PREFIX = "$sys{";
+    public static final String ENV_VAR_PLACEHOLDER_PREFIX = "$env{";
     public static final String PLACEHOLDER_SUFFIX = "}";
 
     public static final class PrimaryKeyStore {
@@ -88,6 +97,8 @@ public class Constants {
         public static final String CARBON_SECRET_PROVIDER = "carbon.secretProvider";
         public static final String SECRET_FILE_PROVIDER = "secretRepositories.file.provider";
         public static final String SECRET_FILE_ALGORITHM= "secretRepositories.file.algorithm";
+        public static final String SECRET_FILE_ENCRYPTION_MODE=
+                "secretRepositories.file.encryptionMode";
         public static final String SECRET_FILE_BASE_PROVIDER_CLASS =
                 "org.wso2.securevault.secret.repository.FileBaseSecretRepositoryProvider";
         public static final String SECRET_FILE_LOCATION = "secretRepositories.file.location";
@@ -109,5 +120,26 @@ public class Constants {
         public static final String BC_FIPS_CLASS_NAME = "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider";
         public static final String BC_CLASS_NAME = "org.bouncycastle.jce.provider.BouncyCastleProvider";
         public static final String FIPS_APPROVED_ONLY = "org.bouncycastle.fips.approved_only";
+    }
+
+    public enum Error {
+
+        GET_KEY_ERROR_MESSAGE("Error retrieving key associated with alias : %s"),
+        CIPHER_INIT_ERROR_MESSAGE("Error initializing Cipher."),
+        INVALID_SECRET_ERROR_MESSAGE("The provided secret key is invalid."),
+        JSON_VALUE_NOT_FOUND("Value \"%s\" not found in JSON"),
+        TOML_NOT_FOUND("Deployment file %s not found"),
+        PARAMETER_REQUIRED_FOR_ROTATE_MODE("%s parameter is required for key rotate mode mode."),
+        INVALID_JSON("Invalid encrypted text: JSON parsing failed.");
+
+        private final String messageTemplate;
+
+        Error(String messageTemplate) {
+            this.messageTemplate = messageTemplate;
+        }
+
+        public String getMessage(Object... args) {
+            return String.format(this.messageTemplate, args);
+        }
     }
 }

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/KeyStoreUtil.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/KeyStoreUtil.java
@@ -37,12 +37,48 @@ import java.security.cert.CertificateException;
 public class KeyStoreUtil {
 
     /**
+     * Retrieves the password for the keystore.
+     *
+     * @return The keystore password.
+     */
+    public static String getKeystorePassword() {
+
+        String password;
+        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? Constants.PRIMARY : Constants.INTERNAL);
+        if (StringUtils.isNotEmpty(System.getProperty(Constants.KEYSTORE_PASSWORD))) {
+            password = System.getProperty(Constants.KEYSTORE_PASSWORD);
+        } else {
+            password = Utils.getValueFromConsole("Please Enter " + keyStoreName + " KeyStore Password of Carbon Server : ", true);
+            System.setProperty(Constants.KEYSTORE_PASSWORD, password);
+        }
+        if (password == null) {
+            throw new CipherToolException("KeyStore password can not be null");
+        }
+        return password;
+    }
+
+    /**
+     * Retrieves the keystore for the Carbon Server.
+     *
+     * @return The keystore.
+     */
+    public static KeyStore getKeyStore() {
+
+        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? Constants.PRIMARY : Constants.INTERNAL);
+        String keyStoreFile = System.getProperty(Constants.KEY_LOCATION_PROPERTY);
+        String keyType = System.getProperty(Constants.KEY_TYPE_PROPERTY);
+        String password = getKeystorePassword();
+        System.out.println("\n" + keyStoreName + " KeyStore of Carbon Server is initialized Successfully\n");
+        return getKeyStore(keyStoreFile, password, keyType);
+    }
+
+    /**
      * Initializes the Cipher
      * @return cipher cipher
      */
     public static Cipher initializeCipher() {
         Cipher cipher;
-        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? "Primary" : "Internal");
+        String keyStoreName = ((Utils.isPrimaryKeyStore()) ? Constants.PRIMARY : Constants.INTERNAL);
         String keyStoreFile = System.getProperty(Constants.KEY_LOCATION_PROPERTY);
         String keyType = System.getProperty(Constants.KEY_TYPE_PROPERTY);
         String keyAlias = System.getProperty(Constants.KEY_ALIAS_PROPERTY);
@@ -81,7 +117,7 @@ public class KeyStoreUtil {
         return cipher;
     }
 
-    private static KeyStore getKeyStore(String location, String storePassword, String storeType) {
+    public static KeyStore getKeyStore(String location, String storePassword, String storeType) {
         BufferedInputStream bufferedInputStream = null;
         try {
             bufferedInputStream = new BufferedInputStream(new FileInputStream(location));

--- a/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
+++ b/components/ciphertool/src/main/java/org/wso2/ciphertool/utils/Utils.java
@@ -27,6 +27,20 @@ import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import java.io.Console;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
@@ -35,15 +49,11 @@ import javax.xml.bind.DatatypeConverter;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.*;
-import java.io.*;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Properties;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
@@ -197,14 +207,17 @@ public class Utils {
         String keyStoreFile = System.getProperty(Constants.KEY_LOCATION_PROPERTY);
         String keyType = System.getProperty(Constants.KEY_TYPE_PROPERTY);
         String aliasName = System.getProperty(Constants.KEY_ALIAS_PROPERTY);
-        String enable = System.getProperty(Constants.SecureVault.ENABLE_SEC_VAULT, "true");
+        String enable = System.getProperty(Constants.SecureVault.ENABLE_SEC_VAULT, Constants.TRUE);
 
         properties.setProperty(Constants.SecureVault.ENABLE_SEC_VAULT, enable);
         properties.setProperty(Constants.SecureVault.CARBON_SECRET_PROVIDER,
                 Constants.SecureVault.SECRET_PROVIDER_CLASS);
         properties.setProperty(Constants.SecureVault.SECRET_REPOSITORIES, "file");
         properties.setProperty(Constants.SecureVault.SECRET_FILE_PROVIDER,
-                               Constants.SecureVault.SECRET_FILE_BASE_PROVIDER_CLASS);
+                Constants.SecureVault.SECRET_FILE_BASE_PROVIDER_CLASS);
+        if (Constants.TRUE.equals((System.getProperty(Constants.SYMMETRIC)))) {
+            properties.setProperty(Constants.SecureVault.SECRET_FILE_ENCRYPTION_MODE, Constants.SYMMETRIC);
+        }
         properties.setProperty(Constants.SecureVault.SECRET_FILE_LOCATION, System.getProperty(
                 Constants.SecureVault.SECRET_FILE_LOCATION));
 
@@ -274,6 +287,14 @@ public class Utils {
 
                 keyStoreFile = resolveKeyStorePath(keyStoreFile, homeFolder);
                 System.setProperty(Constants.KEY_LOCATION_PROPERTY, keyStoreFile);
+                String keyStoreName = ((Utils.isPrimaryKeyStore()) ? Constants.PRIMARY : Constants.INTERNAL);
+
+                if (Constants.TRUE.equals((System.getProperty(Constants.SYMMETRIC)))) {
+                    System.out.println("\nSymmetric encryption using " + keyStoreName + " KeyStore.");
+                } else {
+                    System.out.println("\nAsymmetric encryption using " + keyStoreName + " KeyStore.");
+                }
+                System.out.println("{type: " + keyType + ", alias: " + keyAlias + ", path: " + keyStoreFile + "}\n");
 
                 if (hasConfigInRepository) {
 	                secretConfFile = Constants.REPOSITORY_DIR + File.separator + Constants.CONF_DIR + File.separator +
@@ -403,7 +424,7 @@ public class Utils {
     public static String doEncryption(Cipher cipher, String plainTextPwd) {
         String encodedValue;
         try {
-            byte[] encryptedPassword = cipher.doFinal(plainTextPwd.getBytes(Charset.forName(Constants.UTF8)));
+            byte[] encryptedPassword = cipher.doFinal(plainTextPwd.getBytes(StandardCharsets.UTF_8));
             encodedValue = DatatypeConverter.printBase64Binary(encryptedPassword);
         } catch (BadPaddingException e) {
             throw new CipherToolException("Error encrypting password ", e);
@@ -411,6 +432,25 @@ public class Utils {
             throw new CipherToolException("Error encrypting password ", e);
         }
         System.out.println("\nEncryption is done Successfully\n");
+        return encodedValue;
+    }
+
+    /**
+     * Decrypt the cipher text password.
+     *
+     * @param cipher        Initialized cipher object.
+     * @param cipherTextPwd Encrypted password.
+     * @return Plain text password.
+     */
+    public static String doDecryption(Cipher cipher, byte[] cipherTextPwd) {
+        String encodedValue;
+        try {
+            byte[] encryptedPassword = cipher.doFinal(cipherTextPwd);
+            encodedValue = new String(encryptedPassword);
+        } catch (BadPaddingException | IllegalBlockSizeException e) {
+            throw new CipherToolException("Error decrypting password ", e);
+        }
+        System.out.println("\nDecryption is done Successfully\n");
         return encodedValue;
     }
 
@@ -483,6 +523,20 @@ public class Utils {
         String unEncryptedValue = StringUtils.substring(value, value.indexOf(Constants.SECTION_PREFIX) + 1,
                 value.lastIndexOf(Constants.SECTION_SUFFIX));
         return StringUtils.isNotEmpty(unEncryptedValue) ? unEncryptedValue : null;
+    }
+
+    /**
+     * Returns value from [secrets] section in deployment toml file, if encrypted.
+     *
+     * @param value The input string to be checked
+     * @return The input string if it does not contain '[' or ']' otherwise, returns null.
+     */
+    public static String getEncryptedValue(String value) {
+
+        if (value.contains(Constants.SECTION_PREFIX) && value.contains(Constants.SECTION_SUFFIX)) {
+            return null;
+        }
+        return StringUtils.isNotEmpty(value) ? value : null;
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <orbit.version.axiom>1.2.11.wso2v6</orbit.version.axiom>
         <maven.dependency.plugin.version>2.8</maven.dependency.plugin.version>
         <axiom.version>1.2.11.wso2v11</axiom.version>
-        <gson.version>2.3.1</gson.version>
+        <gson.version>2.9.0</gson.version>
         <commons-cli.version>1.4</commons-cli.version>
         <commons-io.version>2.6</commons-io.version>
         <version.cava-toml>0.5.0</version.cava-toml>


### PR DESCRIPTION
## Purpose
Support AES/GCM/NoPadding and AES/ECB/PKCS5Padding symmetric encryption methods.

Use the following command to configure symmetric encryption
```
sh ciphertool.sh -Dconfigure -Dsymmetric
```

Added a key rotate mode to rotate secret key from asymmetric to symmetric
```
sh ciphertool.sh -Drotate -Dsymmetric -Dold.alias=wso2carbon 
```
This rotate mode can also be use to rotate between symmetric to symmetric and symmetric to asymmetric

Porting https://github.com/wso2/cipher-tool/pull/91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for key rotation with automatic re-encryption of existing values using the new key
  * Added symmetric cipher mode as an encryption option alongside existing asymmetric mode

* **Chores**
  * Updated Gson dependency to version 2.9.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->